### PR TITLE
Installer: Add Inno Setup language support

### DIFF
--- a/deploy/FortFirewall.iss
+++ b/deploy/FortFirewall.iss
@@ -9,6 +9,8 @@
 
 #define APP_EXE		StringChange("{app}\%exe%", "%exe%", APP_EXE_NAME)
 
+#define LANG_PATH AddBackslash(SourcePath) + "Languages"
+
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
@@ -41,15 +43,16 @@ Compression=lzma2/ultra
 SolidCompression=yes
 
 [Languages]
-Name: en; MessagesFile: "compiler:Default.isl"
-Name: de; MessagesFile: "compiler:Languages\German.isl"
-Name: fr; MessagesFile: "compiler:Languages\French.isl"
-Name: it; MessagesFile: "compiler:Languages\Italian.isl"
-Name: ko; MessagesFile: "compiler:Languages\Korean.isl"
-Name: pt; MessagesFile: "compiler:Languages\Portuguese.isl"
-Name: pt_BR; MessagesFile: "compiler:Languages\BrazilianPortuguese.isl"
-Name: ru; MessagesFile: "compiler:Languages\Russian.isl"
-Name: sl; MessagesFile: "compiler:Languages\Slovenian.isl"
+Name: en; MessagesFile: "{#LANG_PATH}\Default.isl"
+Name: de; MessagesFile: "{#LANG_PATH}\German.isl"
+Name: fr; MessagesFile: "{#LANG_PATH}\French.isl"
+Name: it; MessagesFile: "{#LANG_PATH}\Italian.isl"
+Name: ko; MessagesFile: "{#LANG_PATH}\Korean.isl"
+Name: pt; MessagesFile: "{#LANG_PATH}\Portuguese.isl"
+Name: pt_BR; MessagesFile: "{#LANG_PATH}\BrazilianPortuguese.isl"
+Name: ru; MessagesFile: "{#LANG_PATH}\Russian.isl"
+Name: sl; MessagesFile: "{#LANG_PATH}\Slovenian.isl"
+Name: zh_CN; MessagesFile: "{#LANG_PATH}\ChineseSimplified.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"

--- a/deploy/languages/BrazilianPortuguese.isl
+++ b/deploy/languages/BrazilianPortuguese.isl
@@ -1,0 +1,384 @@
+; *** Inno Setup version 6.1.0+ Brazilian Portuguese messages made by Cesar82 cesar.zanetti.82@gmail.com ***
+;
+; To download user-contributed translations of this file, go to:
+;   https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and 
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=Português Brasileiro
+LanguageID=$0416
+LanguageCodePage=1252
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=8
+;WelcomeFontName=Verdana
+;WelcomeFontSize=12
+;TitleFontName=Arial
+;TitleFontSize=29
+;CopyrightFontName=Arial
+;CopyrightFontSize=8
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=Instalador
+SetupWindowTitle=%1 - Instalador
+UninstallAppTitle=Desinstalar
+UninstallAppFullTitle=Desinstalar %1
+
+; *** Misc. common
+InformationTitle=Informação
+ConfirmTitle=Confirmar
+ErrorTitle=Erro
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=Isto instalará o %1. Você deseja continuar?
+LdrCannotCreateTemp=Incapaz de criar um arquivo temporário. Instalação abortada
+LdrCannotExecTemp=Incapaz de executar o arquivo no diretório temporário. Instalação abortada
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1.%n%nErro %2: %3
+SetupFileMissing=Está faltando o arquivo %1 do diretório de instalação. Por favor corrija o problema ou obtenha uma nova cópia do programa.
+SetupFileCorrupt=Os arquivos de instalação estão corrompidos. Por favor obtenha uma nova cópia do programa.
+SetupFileCorruptOrWrongVer=Os arquivos de instalação estão corrompidos ou são incompatíveis com esta versão do instalador. Por favor corrija o problema ou obtenha uma nova cópia do programa.
+InvalidParameter=Um parâmetro inválido foi passado na linha de comando:%n%n%1
+SetupAlreadyRunning=O instalador já está em execução.
+WindowsVersionNotSupported=Este programa não suporta a versão do Windows que seu computador está executando.
+WindowsServicePackRequired=Este programa requer o %1 Service Pack %2 ou superior.
+NotOnThisPlatform=Este programa não executará no %1.
+OnlyOnThisPlatform=Este programa deve ser executado no %1.
+OnlyOnTheseArchitectures=Este programa só pode ser instalado em versões do Windows projetadas para as seguintes arquiteturas de processadores:%n%n% 1
+WinVersionTooLowError=Este programa requer a %1 versão %2 ou superior.
+WinVersionTooHighError=Este programa não pode ser instalado na %1 versão %2 ou superior.
+AdminPrivilegesRequired=Você deve estar logado como administrador quando instalar este programa.
+PowerUserPrivilegesRequired=Você deve estar logado como administrador ou como um membro do grupo de Usuários Power quando instalar este programa.
+SetupAppRunningError=O instalador detectou que o %1 está atualmente em execução.%n%nPor favor feche todas as instâncias dele agora, então clique em OK pra continuar ou em Cancelar pra sair.
+UninstallAppRunningError=O Desinstalador detectou que o %1 está atualmente em execução.%n%nPor favor feche todas as instâncias dele agora, então clique em OK pra continuar ou em Cancelar pra sair.
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=Selecione o Modo de Instalação do Instalador
+PrivilegesRequiredOverrideInstruction=Selecione o modo de instalação
+PrivilegesRequiredOverrideText1=O %1 pode ser instalado pra todos os usuários (requer privilégios administrativos) ou só pra você.
+PrivilegesRequiredOverrideText2=O %1 pode ser instalado só pra você ou pra todos os usuários (requer privilégios administrativos).
+PrivilegesRequiredOverrideAllUsers=Instalar pra &todos os usuários
+PrivilegesRequiredOverrideAllUsersRecommended=Instalar pra &todos os usuários (recomendado)
+PrivilegesRequiredOverrideCurrentUser=Instalar só &pra mim
+PrivilegesRequiredOverrideCurrentUserRecommended=Instalar só &pra mim (recomendado)
+
+; *** Misc. errors
+ErrorCreatingDir=O instalador foi incapaz de criar o diretório "%1"
+ErrorTooManyFilesInDir=Incapaz de criar um arquivo no diretório "%1" porque ele contém arquivos demais
+
+; *** Setup common messages
+ExitSetupTitle=Sair do Instalador
+ExitSetupMessage=A Instalação não está completa. Se você sair agora o programa não será instalado.%n%nVocê pode executar o instalador de novo outra hora pra completar a instalação.%n%nSair do instalador?
+AboutSetupMenuItem=&Sobre o Instalador...
+AboutSetupTitle=Sobre o Instalador
+AboutSetupMessage=%1 versão %2%n%3%n%n%1 home page:%n%4
+AboutSetupNote=
+TranslatorNote=
+
+; *** Buttons
+ButtonBack=< &Voltar
+ButtonNext=&Avançar >
+ButtonInstall=&Instalar
+ButtonOK=OK
+ButtonCancel=Cancelar
+ButtonYes=&Sim
+ButtonYesToAll=Sim pra &Todos
+ButtonNo=&Não
+ButtonNoToAll=Nã&o pra Todos
+ButtonFinish=&Concluir
+ButtonBrowse=&Procurar...
+ButtonWizardBrowse=P&rocurar...
+ButtonNewFolder=&Criar Nova Pasta
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=Selecione o Idioma do Instalador
+SelectLanguageLabel=Selecione o idioma pra usar durante a instalação:
+
+; *** Common wizard text
+ClickNext=Clique em Avançar pra continuar ou em Cancelar pra sair do instalador.
+BeveledLabel=
+BrowseDialogTitle=Procurar Pasta
+BrowseDialogLabel=Selecione uma pasta na lista abaixo, então clique em OK.
+NewFolderName=Nova Pasta
+
+; *** "Welcome" wizard page
+WelcomeLabel1=Bem-vindo ao Assistente do Instalador do [name]
+WelcomeLabel2=Isto instalará o [name/ver] no seu computador.%n%nÉ recomendado que você feche todos os outros aplicativos antes de continuar.
+
+; *** "Password" wizard page
+WizardPassword=Senha
+PasswordLabel1=Esta instalação está protegida por senha.
+PasswordLabel3=Por favor forneça a senha, então clique em Avançar pra continuar. As senhas são caso-sensitivo.
+PasswordEditLabel=&Senha:
+IncorrectPassword=A senha que você inseriu não está correta. Por favor tente de novo.
+
+; *** "License Agreement" wizard page
+WizardLicense=Acordo de Licença
+LicenseLabel=Por favor leia as seguintes informações importantes antes de continuar.
+LicenseLabel3=Por favor leia o seguinte Acordo de Licença. Você deve aceitar os termos deste acordo antes de continuar com a instalação.
+LicenseAccepted=Eu &aceito o acordo
+LicenseNotAccepted=Eu &não aceito o acordo
+
+; *** "Information" wizard pages
+WizardInfoBefore=Informação
+InfoBeforeLabel=Por favor leia as seguintes informações importantes antes de continuar.
+InfoBeforeClickLabel=Quando você estiver pronto pra continuar com o instalador, clique em Avançar.
+WizardInfoAfter=Informação
+InfoAfterLabel=Por favor leia as seguintes informações importantes antes de continuar.
+InfoAfterClickLabel=Quando você estiver pronto pra continuar com o instalador, clique em Avançar.
+
+; *** "User Information" wizard page
+WizardUserInfo=Informação do Usuário
+UserInfoDesc=Por favor insira suas informações.
+UserInfoName=&Nome do Usuário:
+UserInfoOrg=&Organização:
+UserInfoSerial=&Número de Série:
+UserInfoNameRequired=Você deve inserir um nome.
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=Selecione o Local de Destino
+SelectDirDesc=Aonde o [name] deve ser instalado?
+SelectDirLabel3=O instalador instalará o [name] na seguinte pasta.
+SelectDirBrowseLabel=Pra continuar clique em Avançar. Se você gostaria de selecionar uma pasta diferente, clique em Procurar.
+DiskSpaceGBLabel=Pelo menos [gb] MBs de espaço livre em disco são requeridos.
+DiskSpaceMBLabel=Pelo menos [mb] MBs de espaço livre em disco são requeridos.
+CannotInstallToNetworkDrive=O instalador não pode instalar em um drive de rede.
+CannotInstallToUNCPath=O instalador não pode instalar em um caminho UNC.
+InvalidPath=Você deve inserir um caminho completo com a letra do drive; por exemplo:%n%nC:\APP%n%não um caminho UNC no formulário:%n%n\\server\share
+InvalidDrive=O drive ou compartilhamento UNC que você selecionou não existe ou não está acessível. Por favor selecione outro.
+DiskSpaceWarningTitle=Sem Espaço em Disco o Bastante
+DiskSpaceWarning=O instalador requer pelo menos %1 KBs de espaço livre pra instalar mas o drive selecionado só tem %2 KBs disponíveis.%n%nVocê quer continuar de qualquer maneira?
+DirNameTooLong=O nome ou caminho da pasta é muito longo.
+InvalidDirName=O nome da pasta não é válido.
+BadDirName32=Os nomes das pastas não pode incluir quaisquer dos seguintes caracteres:%n%n%1
+DirExistsTitle=A Pasta Existe
+DirExists=A pasta:%n%n%1%n%njá existe. Você gostaria de instalar nesta pasta de qualquer maneira?
+DirDoesntExistTitle=A Pasta Não Existe
+DirDoesntExist=A pasta:%n%n%1%n%nnão existe. Você gostaria quer a pasta fosse criada?
+
+; *** "Select Components" wizard page
+WizardSelectComponents=Selecionar Componentes
+SelectComponentsDesc=Quais componentes devem ser instalados?
+SelectComponentsLabel2=Selecione os componentes que você quer instalar; desmarque os componentes que você não quer instalar. Clique em Avançar quando você estiver pronto pra continuar.
+FullInstallation=Instalação completa
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=Instalação compacta
+CustomInstallation=Instalação personalizada
+NoUninstallWarningTitle=O Componente Existe
+NoUninstallWarning=O instalador detectou que os seguintes componentes já estão instalados no seu computador:%n%n%1%n%nNão selecionar estes componentes não desinstalará eles.%n%nVocê gostaria de continuar de qualquer maneira?
+ComponentSize1=%1 KBs
+ComponentSize2=%1 MBs
+ComponentsDiskSpaceGBLabel=A seleção atual requer pelo menos [gb] MBs de espaço em disco.
+ComponentsDiskSpaceMBLabel=A seleção atual requer pelo menos [mb] MBs de espaço em disco.
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=Selecionar Tarefas Adicionais
+SelectTasksDesc=Quais tarefas adicionais devem ser executadas?
+SelectTasksLabel2=Selecione as tarefas adicionais que você gostaria que o instalador executasse enquanto instala o [name], então clique em Avançar.
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=Selecionar a Pasta do Menu Iniciar
+SelectStartMenuFolderDesc=Aonde o instalador deve colocar os atalhos do programa?
+SelectStartMenuFolderLabel3=O instalador criará os atalhos do programa na seguinte pasta do Menu Iniciar.
+SelectStartMenuFolderBrowseLabel=Pra continuar clique em Avançar. Se você gostaria de selecionar uma pasta diferente, clique em Procurar.
+MustEnterGroupName=Você deve inserir um nome de pasta.
+GroupNameTooLong=O nome ou caminho da pasta é muito longo.
+InvalidGroupName=O nome da pasta não é válido.
+BadGroupName=O nome da pasta não pode incluir quaisquer dos seguintes caracteres:%n%n%1
+NoProgramGroupCheck2=&Não criar uma pasta no Menu Iniciar
+
+; *** "Ready to Install" wizard page
+WizardReady=Pronto pra Instalar
+ReadyLabel1=O instalador está agora pronto pra começar a instalar o [name] no seu computador.
+ReadyLabel2a=Clique em Instalar pra continuar com a instalação ou clique em Voltar se você quer revisar ou mudar quaisquer configurações.
+ReadyLabel2b=Clique em Instalar pra continuar com a instalação.
+ReadyMemoUserInfo=Informação do usuário:
+ReadyMemoDir=Local de destino:
+ReadyMemoType=Tipo de instalação:
+ReadyMemoComponents=Componentes selecionados:
+ReadyMemoGroup=Pasta do Menu Iniciar:
+ReadyMemoTasks=Tarefas adicionais:
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel=Baixando arquivos adicionais...
+ButtonStopDownload=&Parar download
+StopDownload=Tem certeza que deseja parar o download?
+ErrorDownloadAborted=Download abortado
+ErrorDownloadFailed=Download falhou: %1 %2
+ErrorDownloadSizeFailed=Falha ao obter o tamanho: %1 %2
+ErrorFileHash1=Falha no hash do arquivo: %1
+ErrorFileHash2=Hash de arquivo inválido: esperado %1, encontrado %2
+ErrorProgress=Progresso inválido: %1 de %2
+ErrorFileSize=Tamanho de arquivo inválido: esperado %1, encontrado %2
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=Preparando pra Instalar
+PreparingDesc=O instalador está se preparando pra instalar o [name] no seu computador.
+PreviousInstallNotCompleted=A instalação/remoção de um programa anterior não foi completada. Você precisará reiniciar o computador pra completar essa instalação.%n%nApós reiniciar seu computador execute o instalador de novo pra completar a instalação do [name].
+CannotContinue=O instalador não pode continuar. Por favor clique em Cancelar pra sair.
+ApplicationsFound=Os aplicativos a seguir estão usando arquivos que precisam ser atualizados pelo instalador. É recomendados que você permita ao instalador fechar automaticamente estes aplicativos.
+ApplicationsFound2=Os aplicativos a seguir estão usando arquivos que precisam ser atualizados pelo instalador. É recomendados que você permita ao instalador fechar automaticamente estes aplicativos. Após a instalação ter completado, o instalador tentará reiniciar os aplicativos.
+CloseApplications=&Fechar os aplicativos automaticamente
+DontCloseApplications=&Não fechar os aplicativos
+ErrorCloseApplications=O instalador foi incapaz de fechar automaticamente todos os aplicativos. É recomendado que você feche todos os aplicativos usando os arquivos que precisam ser atualizados pelo instalador antes de continuar.
+PrepareToInstallNeedsRestart=A instalação deve reiniciar seu computador. Depois de reiniciar o computador, execute a Instalação novamente para concluir a instalação de [name].%n%nDeseja reiniciar agora?
+
+; *** "Installing" wizard page
+WizardInstalling=Instalando
+InstallingLabel=Por favor espere enquanto o instalador instala o [name] no seu computador.
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=Completando o Assistente do Instalador do [name]
+FinishedLabelNoIcons=O instalador terminou de instalar o [name] no seu computador.
+FinishedLabel=O instalador terminou de instalar o [name] no seu computador. O aplicativo pode ser iniciado selecionando os atalhos instalados.
+ClickFinish=Clique em Concluir pra sair do Instalador.
+FinishedRestartLabel=Pra completar a instalação do [name], o instalador deve reiniciar seu computador. Você gostaria de reiniciar agora?
+FinishedRestartMessage=Pra completar a instalação do [name], o instalador deve reiniciar seu computador.%n%nVocê gostaria de reiniciar agora?
+ShowReadmeCheck=Sim, eu gostaria de visualizar o arquivo README
+YesRadio=&Sim, reiniciar o computador agora
+NoRadio=&Não, eu reiniciarei o computador depois
+; used for example as 'Run MyProg.exe'
+RunEntryExec=Executar %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=Visualizar %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=O Instalador Precisa do Próximo Disco
+SelectDiskLabel2=Por favor insira o Disco %1 e clique em OK.%n%nSe os arquivos neste disco podem ser achados numa pasta diferente do que a exibida abaixo, insira o caminho correto ou clique em Procurar.
+PathLabel=&Caminho:
+FileNotInDir2=O arquivo "%1" não pôde ser localizado em "%2". Por favor insira o disco correto ou selecione outra pasta.
+SelectDirectoryLabel=Por favor especifique o local do próximo disco.
+
+; *** Installation phase messages
+SetupAborted=A instalação não foi completada.%n%nPor favor corrija o problema e execute o instalador de novo.
+AbortRetryIgnoreSelectAction=Selecionar ação
+AbortRetryIgnoreRetry=&Tentar de novo
+AbortRetryIgnoreIgnore=&Ignorar o erro e continuar
+AbortRetryIgnoreCancel=Cancelar instalação
+
+; *** Installation status messages
+StatusClosingApplications=Fechando aplicativos...
+StatusCreateDirs=Criando diretórios...
+StatusExtractFiles=Extraindo arquivos...
+StatusCreateIcons=Criando atalhos...
+StatusCreateIniEntries=Criando entradas INI...
+StatusCreateRegistryEntries=Criando entradas do registro...
+StatusRegisterFiles=Registrando arquivos...
+StatusSavingUninstall=Salvando informações de desinstalação...
+StatusRunProgram=Concluindo a instalação...
+StatusRestartingApplications=Reiniciando os aplicativos...
+StatusRollback=Desfazendo as mudanças...
+
+; *** Misc. errors
+ErrorInternal2=Erro interno: %1
+ErrorFunctionFailedNoCode=%1 falhou
+ErrorFunctionFailed=%1 falhou; código %2
+ErrorFunctionFailedWithMessage=%1 falhou; código %2.%n%3
+ErrorExecutingProgram=Incapaz de executar o arquivo:%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=Erro ao abrir a chave do registro:%n%1\%2
+ErrorRegCreateKey=Erro ao criar a chave do registro:%n%1\%2
+ErrorRegWriteKey=Erro ao gravar a chave do registro:%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=Erro ao criar a entrada INI no arquivo "%1".
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=&Ignorar este arquivo (não recomendado)
+FileAbortRetryIgnoreIgnoreNotRecommended=&Ignorar o erro e continuar (não recomendado)
+SourceIsCorrupted=O arquivo de origem está corrompido
+SourceDoesntExist=O arquivo de origem "%1" não existe
+ExistingFileReadOnly2=O arquivo existente não pôde ser substituído porque está marcado como somente-leitura.
+ExistingFileReadOnlyRetry=&Remover o atributo somente-leitura e tentar de novo
+ExistingFileReadOnlyKeepExisting=&Manter o arquivo existente
+ErrorReadingExistingDest=Um erro ocorreu enquanto tentava ler o arquivo existente:
+FileExistsSelectAction=Selecione a ação
+FileExists2=O arquivo já existe.
+FileExistsOverwriteExisting=&Sobrescrever o arquivo existente
+FileExistsKeepExisting=&Mantenha o arquivo existente
+FileExistsOverwriteOrKeepAll=&Faça isso para os próximos conflitos
+ExistingFileNewerSelectAction=Selecione a ação
+ExistingFileNewer2=O arquivo existente é mais recente do que aquele que o Setup está tentando instalar.
+ExistingFileNewerOverwriteExisting=&Sobrescrever o arquivo existente
+ExistingFileNewerKeepExisting=&Mantenha o arquivo existente (recomendado)
+ExistingFileNewerOverwriteOrKeepAll=&Faça isso para os próximos conflitos
+ErrorChangingAttr=Um erro ocorreu enquanto tentava mudar os atributos do arquivo existente:
+ErrorCreatingTemp=Um erro ocorreu enquanto tentava criar um arquivo no diretório destino:
+ErrorReadingSource=Um erro ocorreu enquanto tentava ler o arquivo de origem:
+ErrorCopying=Um erro ocorreu enquanto tentava copiar um arquivo:
+ErrorReplacingExistingFile=Um erro ocorreu enquanto tentava substituir o arquivo existente:
+ErrorRestartReplace=ReiniciarSubstituir falhou:
+ErrorRenamingTemp=Um erro ocorreu enquanto tentava renomear um arquivo no diretório destino:
+ErrorRegisterServer=Incapaz de registrar a DLL/OCX: %1
+ErrorRegSvr32Failed=O RegSvr32 falhou com o código de saída %1
+ErrorRegisterTypeLib=Incapaz de registrar a biblioteca de tipos: %1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32 bits
+UninstallDisplayNameMark64Bit=64 bits
+UninstallDisplayNameMarkAllUsers=Todos os usuários
+UninstallDisplayNameMarkCurrentUser=Usuário atual
+
+; *** Post-installation errors
+ErrorOpeningReadme=Um erro ocorreu enquanto tentava abrir o arquivo README.
+ErrorRestartingComputer=O instalador foi incapaz de reiniciar o computador. Por favor faça isto manualmente.
+
+; *** Uninstaller messages
+UninstallNotFound=O arquivo "%1" não existe. Não consegue desinstalar.
+UninstallOpenError=O arquivo "%1" não pôde ser aberto. Não consegue desinstalar
+UninstallUnsupportedVer=O arquivo do log da desinstalação "%1" está num formato não reconhecido por esta versão do desinstalador. Não consegue desinstalar
+UninstallUnknownEntry=Uma entrada desconhecida (%1) foi encontrada no log da desinstalação
+ConfirmUninstall=Você tem certeza que você quer remover completamente o %1 e todos os seus componentes?
+UninstallOnlyOnWin64=Esta instalação só pode ser desinstalada em Windows 64 bits.
+OnlyAdminCanUninstall=Esta instalação só pode ser desinstalada por um usuário com privilégios administrativos.
+UninstallStatusLabel=Por favor espere enquanto o %1 é removido do seu computador.
+UninstalledAll=O %1 foi removido com sucesso do seu computador.
+UninstalledMost=Desinstalação do %1 completa.%n%nAlguns elementos não puderam ser removidos. Estes podem ser removidos manualmente.
+UninstalledAndNeedsRestart=Pra completar a desinstalação do %1, seu computador deve ser reiniciado.%n%nVocê gostaria de reiniciar agora?
+UninstallDataCorrupted=O arquivo "%1" está corrompido. Não consegue desinstalar
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=Remover Arquivo Compartilhado?
+ConfirmDeleteSharedFile2=O sistema indica que o seguinte arquivo compartilhado não está mais em uso por quaisquer programas. Você gostaria que a Desinstalação removesse este arquivo compartilhado?%n%nSe quaisquer programas ainda estão usando este arquivo e ele é removido, esses programas podem não funcionar apropriadamente. Se você não tiver certeza escolha Não. Deixar o arquivo no seu sistema não causará qualquer dano.
+SharedFileNameLabel=Nome do arquivo:
+SharedFileLocationLabel=Local:
+WizardUninstalling=Status da Desinstalação
+StatusUninstalling=Desinstalando o %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=Instalando o %1.
+ShutdownBlockReasonUninstallingApp=Desinstalando o %1.
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 versão %2
+AdditionalIcons=Atalhos adicionais:
+CreateDesktopIcon=Criar um atalho &na área de trabalho
+CreateQuickLaunchIcon=Criar um atalho na &barra de inicialização rápida
+ProgramOnTheWeb=%1 na Web
+UninstallProgram=Desinstalar o %1
+LaunchProgram=Iniciar o %1
+AssocFileExtension=&Associar o %1 com a extensão do arquivo %2
+AssocingFileExtension=Associando o %1 com a extensão do arquivo %2...
+AutoStartProgramGroupDescription=Inicialização:
+AutoStartProgram=Iniciar o %1 automaticamente
+AddonHostProgramNotFound=O %1 não pôde ser localizado na pasta que você selecionou.%n%nVocê quer continuar de qualquer maneira?

--- a/deploy/languages/ChineseSimplified.isl
+++ b/deploy/languages/ChineseSimplified.isl
@@ -1,0 +1,394 @@
+﻿; *** Inno Setup version 6.1.0+ Chinese Simplified messages ***
+;
+; To download user-contributed translations of this file, go to:
+;   https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+;
+; Maintained by Zhenghan Yang
+; Email: 847320916@QQ.com
+; Translation based on network resource
+; The latest Translation is on https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+;
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and 
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=简体中文
+; If Language Name display incorrect, uncomment next line
+; LanguageName=<7B80><4F53><4E2D><6587>
+; About LanguageID, to reference link:
+; https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c
+LanguageID=$0804
+LanguageCodePage=936
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=8
+;WelcomeFontName=Verdana
+;WelcomeFontSize=12
+;TitleFontName=Arial
+;TitleFontSize=29
+;CopyrightFontName=Arial
+;CopyrightFontSize=8
+
+[Messages]
+
+; *** 应用程序标题
+SetupAppTitle=安装
+SetupWindowTitle=安装 - %1
+UninstallAppTitle=卸载
+UninstallAppFullTitle=%1 卸载
+
+; *** Misc. common
+InformationTitle=信息
+ConfirmTitle=确认
+ErrorTitle=错误
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=现在将安装 %1。您想要继续吗？
+LdrCannotCreateTemp=不能创建临时文件。安装中断。
+LdrCannotExecTemp=不能执行临时目录中的文件。安装中断。
+HelpTextNote=
+
+; *** 启动错误消息
+LastErrorMessage=%1.%n%n错误 %2: %3
+SetupFileMissing=安装目录中的文件 %1 丢失。请修正这个问题或者获取程序的新副本。
+SetupFileCorrupt=安装文件已损坏。请获取程序的新副本。
+SetupFileCorruptOrWrongVer=安装文件已损坏，或是与这个安装程序的版本不兼容。请修正这个问题或获取新的程序副本。
+InvalidParameter=无效的命令行参数：%n%n%1
+SetupAlreadyRunning=安装程序正在运行。
+WindowsVersionNotSupported=这个程序不支持当前计算机运行的Windows版本。
+WindowsServicePackRequired=这个程序需要 %1 服务包 %2 或更高。
+NotOnThisPlatform=这个程序将不能运行于 %1。
+OnlyOnThisPlatform=这个程序必须运行于 %1。
+OnlyOnTheseArchitectures=这个程序只能在为下列处理器结构设计的Windows版本中进行安装：%n%n%1
+WinVersionTooLowError=这个程序需要 %1 版本 %2 或更高。
+WinVersionTooHighError=这个程序不能安装于 %1 版本 %2 或更高。
+AdminPrivilegesRequired=在安装这个程序时您必须以管理员身份登录。
+PowerUserPrivilegesRequired=在安装这个程序时您必须以管理员身份或有权限的用户组身份登录。
+SetupAppRunningError=安装程序发现 %1 当前正在运行。%n%n请先关闭所有运行的窗口，然后点击“确定”继续，或按“取消”退出。
+UninstallAppRunningError=卸载程序发现 %1 当前正在运行。%n%n请先关闭所有运行的窗口，然后点击“确定”继续，或按“取消”退出。
+
+; *** 启动问题
+PrivilegesRequiredOverrideTitle=选择安装程序模式
+PrivilegesRequiredOverrideInstruction=选择安装模式
+PrivilegesRequiredOverrideText1=%1 可以为所有用户安装(需要管理员权限)，或仅为您安装。
+PrivilegesRequiredOverrideText2=%1 只能为您安装，或为所有用户安装(需要管理员权限)。
+PrivilegesRequiredOverrideAllUsers=为所有用户安装(&A)
+PrivilegesRequiredOverrideAllUsersRecommended=为所有用户安装(&A) (建议选项)
+PrivilegesRequiredOverrideCurrentUser=只为我安装(&M)
+PrivilegesRequiredOverrideCurrentUserRecommended=只为我安装(&M) (建议选项)
+
+; *** 其它错误
+ErrorCreatingDir=安装程序不能创建目录“%1”。
+ErrorTooManyFilesInDir=不能在目录“%1”中创建文件，因为里面的文件太多
+
+; *** 安装程序公共消息
+ExitSetupTitle=退出安装程序
+ExitSetupMessage=安装程序还未完成安装。如果您现在退出，程序将不能安装。%n%n您可以以后再运行安装程序完成安装。%n%n现在退出安装程序吗？
+AboutSetupMenuItem=关于安装程序(&A)...
+AboutSetupTitle=关于安装程序
+AboutSetupMessage=%1 版本 %2%n%3%n%n%1 主页：%n%4
+AboutSetupNote=
+TranslatorNote=
+
+; *** 按钮
+ButtonBack=< 上一步(&B)
+ButtonNext=下一步(&N) >
+ButtonInstall=安装(&I)
+ButtonOK=确定
+ButtonCancel=取消
+ButtonYes=是(&Y)
+ButtonYesToAll=全是(&A)
+ButtonNo=否(&N)
+ButtonNoToAll=全否(&O)
+ButtonFinish=完成(&F)
+ButtonBrowse=浏览(&B)...
+ButtonWizardBrowse=浏览(&R)...
+ButtonNewFolder=新建文件夹(&M)
+
+; *** “选择语言”对话框消息
+SelectLanguageTitle=选择安装语言
+SelectLanguageLabel=选择安装时要使用的语言。
+
+; *** 公共向导文字
+ClickNext=点击“下一步”继续，或点击“取消”退出安装程序。
+BeveledLabel=
+BrowseDialogTitle=浏览文件夹
+BrowseDialogLabel=在下列列表中选择一个文件夹，然后点击“确定”。
+NewFolderName=新建文件夹
+
+; *** “欢迎”向导页
+WelcomeLabel1=欢迎使用 [name] 安装向导
+WelcomeLabel2=现在将安装 [name/ver] 到您的电脑中。%n%n推荐您在继续安装前关闭所有其它应用程序。
+
+; *** “密码”向导页
+WizardPassword=密码
+PasswordLabel1=这个安装程序有密码保护。
+PasswordLabel3=请输入密码，然后点击“下一步”继续。密码区分大小写。
+PasswordEditLabel=密码(&P)：
+IncorrectPassword=您所输入的密码不正确，请重试。
+
+; *** “许可协议”向导页
+WizardLicense=许可协议
+LicenseLabel=继续安装前请阅读下列重要信息。
+LicenseLabel3=请仔细阅读下列许可协议。您在继续安装前必须同意这些协议条款。
+LicenseAccepted=我同意此协议(&A)
+LicenseNotAccepted=我不同意此协议(&D)
+
+; *** “信息”向导页
+WizardInfoBefore=信息
+InfoBeforeLabel=请在继续安装前阅读下列重要信息。
+InfoBeforeClickLabel=如果您想继续安装，点击“下一步”。
+WizardInfoAfter=信息
+InfoAfterLabel=请在继续安装前阅读下列重要信息。
+InfoAfterClickLabel=如果您想继续安装，点击“下一步”。
+
+; *** “用户信息”向导页
+WizardUserInfo=用户信息
+UserInfoDesc=请输入您的信息。
+UserInfoName=用户名(&U)：
+UserInfoOrg=组织(&O)：
+UserInfoSerial=序列号(&S)：
+UserInfoNameRequired=您必须输入用户名。
+
+; *** “选择目标目录”向导页
+WizardSelectDir=选择目标位置
+SelectDirDesc=您想将 [name] 安装在哪里？
+SelectDirLabel3=安装程序将安装 [name] 到下列文件夹中。
+SelectDirBrowseLabel=点击“下一步”继续。如果您想选择其它文件夹，点击“浏览”。
+DiskSpaceGBLabel=至少需要有 [gb] GB 的可用磁盘空间。
+DiskSpaceMBLabel=至少需要有 [mb] MB 的可用磁盘空间。
+CannotInstallToNetworkDrive=安装程序无法安装到一个网络驱动器。
+CannotInstallToUNCPath=安装程序无法安装到一个UNC路径。
+InvalidPath=您必须输入一个带驱动器卷标的完整路径，例如：%n%nC:\APP%n%n或下列形式的UNC路径：%n%n\\server\share
+InvalidDrive=您选定的驱动器或 UNC 共享不存在或不能访问。请选选择其它位置。
+DiskSpaceWarningTitle=没有足够的磁盘空间
+DiskSpaceWarning=安装程序至少需要 %1 KB 的可用空间才能安装，但选定驱动器只有 %2 KB 的可用空间。%n%n您一定要继续吗？
+DirNameTooLong=文件夹名称或路径太长。
+InvalidDirName=文件夹名称无效。
+BadDirName32=文件夹名称不能包含下列任何字符：%n%n%1
+DirExistsTitle=文件夹已存在
+DirExists=文件夹：%n%n%1%n%n已经存在。您一定要安装到这个文件夹中吗？
+DirDoesntExistTitle=文件夹不存在
+DirDoesntExist=文件夹：%n%n%1%n%n不存在。您想要创建此文件夹吗？
+
+; *** “选择组件”向导页
+WizardSelectComponents=选择组件
+SelectComponentsDesc=您想安装哪些程序的组件？
+SelectComponentsLabel2=选择您想要安装的组件；清除您不想安装的组件。然后点击“下一步”继续。
+FullInstallation=完全安装
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=简洁安装
+CustomInstallation=自定义安装
+NoUninstallWarningTitle=组件已存在
+NoUninstallWarning=安装程序检测到下列组件已在您的电脑中安装：%n%n%1%n%n取消选定这些组件将不能卸载它们。%n%n您一定要继续吗？
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=当前选择的组件至少需要 [gb] GB 的磁盘空间。
+ComponentsDiskSpaceMBLabel=当前选择的组件至少需要 [mb] MB 的磁盘空间。
+
+; *** “选择附加任务”向导页
+WizardSelectTasks=选择附加任务
+SelectTasksDesc=您想要安装程序执行哪些附加任务？
+SelectTasksLabel2=选择您想要安装程序在安装 [name] 时执行的附加任务，然后点击“下一步”。
+
+; *** “选择开始菜单文件夹”向导页
+WizardSelectProgramGroup=选择开始菜单文件夹
+SelectStartMenuFolderDesc=安装程序应该在哪里放置程序的快捷方式？
+SelectStartMenuFolderLabel3=安装程序现在将在下列开始菜单文件夹中创建程序的快捷方式。
+SelectStartMenuFolderBrowseLabel=点击“下一步”继续。如果您想选择其它文件夹，点击“浏览”。
+MustEnterGroupName=您必须输入一个文件夹名。
+GroupNameTooLong=文件夹名或路径太长。
+InvalidGroupName=文件夹名是无效的。
+BadGroupName=文件夹名不能包含下列任何字符：%n%n%1
+NoProgramGroupCheck2=不创建开始菜单文件夹(&D)
+
+; *** “准备安装”向导页
+WizardReady=准备安装
+ReadyLabel1=安装程序现在准备开始安装 [name] 到您的电脑中。
+ReadyLabel2a=点击“安装”继续此安装程序。如果您想要回顾或修改设置，请点击“上一步”。
+ReadyLabel2b=点击“安装”继续此安装程序？
+ReadyMemoUserInfo=用户信息：
+ReadyMemoDir=目标位置：
+ReadyMemoType=安装类型：
+ReadyMemoComponents=选定组件：
+ReadyMemoGroup=开始菜单文件夹：
+ReadyMemoTasks=附加任务：
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel=正在下载附加文件...
+ButtonStopDownload=停止下载(&S)
+StopDownload=您确定要停止下载吗？
+ErrorDownloadAborted=下载已中止
+ErrorDownloadFailed=下载失败：%1 %2
+ErrorDownloadSizeFailed=获取下载大小失败：%1 %2
+ErrorFileHash1=校验文件哈希失败：%1
+ErrorFileHash2=无效的文件哈希：预期 %1，实际 %2
+ErrorProgress=无效的进度：%1，总共%2
+ErrorFileSize=文件大小错误：预期 %1，实际 %2
+
+; *** “正在准备安装”向导页
+WizardPreparing=正在准备安装
+PreparingDesc=安装程序正在准备安装 [name] 到您的电脑中。
+PreviousInstallNotCompleted=先前程序的安装/卸载未完成。您需要重新启动您的电脑才能完成安装。%n%n在重新启动电脑后，再运行安装完成 [name] 的安装。
+CannotContinue=安装程序不能继续。请点击“取消”退出。
+ApplicationsFound=下列应用程序正在使用的文件需要更新设置。它是建议您允许安装程序自动关闭这些应用程序。
+ApplicationsFound2=下列应用程序正在使用的文件需要更新设置。它是建议您允许安装程序自动关闭这些应用程序。安装完成后，安装程序将尝试重新启动应用程序。
+CloseApplications=自动关闭该应用程序(&A)
+DontCloseApplications=不要关闭该应用程序(&D)
+ErrorCloseApplications=安装程序无法自动关闭所有应用程序。在继续之前，我们建议您关闭所有使用需要更新的安装程序文件。
+PrepareToInstallNeedsRestart=安装程序必须重新启动计算机。重新启动计算机后，请再次运行安装程序以完成 [name] 的安装。%n%n是否立即重新启动？
+
+; *** “正在安装”向导页
+WizardInstalling=正在安装
+InstallingLabel=安装程序正在安装 [name] 到您的电脑中，请稍等。
+
+; *** “安装完成”向导页
+FinishedHeadingLabel=[name] 安装完成
+FinishedLabelNoIcons=安装程序已在您的电脑中安装了 [name]。
+FinishedLabel=安装程序已在您的电脑中安装了 [name]。此应用程序可以通过选择安装的快捷方式运行。
+ClickFinish=点击“完成”退出安装程序。
+FinishedRestartLabel=要完成 [name] 的安装，安装程序必须重新启动您的电脑。您想要立即重新启动吗？
+FinishedRestartMessage=要完成 [name] 的安装，安装程序必须重新启动您的电脑。%n%n您想要立即重新启动吗？
+ShowReadmeCheck=是，我想查阅自述文件
+YesRadio=是，立即重新启动电脑(&Y)
+NoRadio=否，稍后重新启动电脑(&N)
+; used for example as 'Run MyProg.exe'
+RunEntryExec=运行 %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=查阅 %1
+
+; *** “安装程序需要下一张磁盘”提示
+ChangeDiskTitle=安装程序需要下一张磁盘
+SelectDiskLabel2=请插入磁盘 %1 并点击“确定”。%n%n如果这个磁盘中的文件可以在下列文件夹之外的文件夹中找到，请输入正确的路径或点击“浏览”。
+PathLabel=路径(&P)：
+FileNotInDir2=文件“%1”不能在“%2”定位。请插入正确的磁盘或选择其它文件夹。
+SelectDirectoryLabel=请指定下一张磁盘的位置。
+
+; *** 安装状态消息
+SetupAborted=安装程序未完成安装。%n%n请修正这个问题并重新运行安装程序。
+AbortRetryIgnoreSelectAction=选择操作
+AbortRetryIgnoreRetry=重试(&T)
+AbortRetryIgnoreIgnore=忽略错误并继续(&I)
+AbortRetryIgnoreCancel=关闭安装程序
+
+; *** 安装状态消息
+StatusClosingApplications=正在关闭应用程序...
+StatusCreateDirs=正在创建目录...
+StatusExtractFiles=正在解压缩文件...
+StatusCreateIcons=正在创建快捷方式...
+StatusCreateIniEntries=正在创建 INI 条目...
+StatusCreateRegistryEntries=正在创建注册表条目...
+StatusRegisterFiles=正在注册文件...
+StatusSavingUninstall=正在保存卸载信息...
+StatusRunProgram=正在完成安装...
+StatusRestartingApplications=正在重启应用程序...
+StatusRollback=正在撤销更改...
+
+; *** 其它错误
+ErrorInternal2=内部错误：%1
+ErrorFunctionFailedNoCode=%1 失败
+ErrorFunctionFailed=%1 失败；错误代码 %2
+ErrorFunctionFailedWithMessage=%1 失败；错误代码 %2.%n%3
+ErrorExecutingProgram=不能执行文件：%n%1
+
+; *** 注册表错误
+ErrorRegOpenKey=打开注册表项时出错：%n%1\%2
+ErrorRegCreateKey=创建注册表项时出错：%n%1\%2
+ErrorRegWriteKey=写入注册表项时出错：%n%1\%2
+
+; *** INI 错误
+ErrorIniEntry=在文件“%1”中创建INI条目时出错。
+
+; *** 文件复制错误
+FileAbortRetryIgnoreSkipNotRecommended=跳过这个文件(&S) (不推荐)
+FileAbortRetryIgnoreIgnoreNotRecommended=忽略错误并继续(&I) (不推荐)
+SourceIsCorrupted=源文件已损坏
+SourceDoesntExist=源文件“%1”不存在
+ExistingFileReadOnly2=无法替换现有文件，因为它是只读的。
+ExistingFileReadOnlyRetry=移除只读属性并重试(&R)
+ExistingFileReadOnlyKeepExisting=保留现有文件(&K)
+ErrorReadingExistingDest=尝试读取现有文件时出错：
+FileExistsSelectAction=选择操作
+FileExists2=文件已经存在。
+FileExistsOverwriteExisting=覆盖已经存在的文件(&O)
+FileExistsKeepExisting=保留现有的文件(&K)
+FileExistsOverwriteOrKeepAll=为所有的冲突文件执行此操作(&D)
+ExistingFileNewerSelectAction=选择操作
+ExistingFileNewer2=现有的文件比安装程序将要安装的文件更新。
+ExistingFileNewerOverwriteExisting=覆盖已经存在的文件(&O)
+ExistingFileNewerKeepExisting=保留现有的文件(&K) (推荐)
+ExistingFileNewerOverwriteOrKeepAll=为所有的冲突文件执行此操作(&D)
+ErrorChangingAttr=尝试改变下列现有的文件的属性时出错：
+ErrorCreatingTemp=尝试在目标目录创建文件时出错：
+ErrorReadingSource=尝试读取下列源文件时出错：
+ErrorCopying=尝试复制下列文件时出错：
+ErrorReplacingExistingFile=尝试替换现有的文件时出错：
+ErrorRestartReplace=重新启动替换失败：
+ErrorRenamingTemp=尝试重新命名以下目标目录中的一个文件时出错：
+ErrorRegisterServer=无法注册 DLL/OCX：%1
+ErrorRegSvr32Failed=RegSvr32 失败；退出代码 %1
+ErrorRegisterTypeLib=无法注册类型库：%1
+
+; *** 卸载显示名字标记
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32位
+UninstallDisplayNameMark64Bit=64位
+UninstallDisplayNameMarkAllUsers=所有用户
+UninstallDisplayNameMarkCurrentUser=当前用户
+
+; *** 安装后错误
+ErrorOpeningReadme=尝试打开自述文件时出错。
+ErrorRestartingComputer=安装程序不能重新启动电脑，请手动重启。
+
+; *** 卸载消息
+UninstallNotFound=文件“%1”不存在。无法卸载。
+UninstallOpenError=文件“%1”不能打开。无法卸载。
+UninstallUnsupportedVer=此版本的卸载程序无法识别卸载日志文件“%1”的格式。无法卸载
+UninstallUnknownEntry=在卸载日志中遇到一个未知的条目 (%1)
+ConfirmUninstall=您确认想要完全删除 %1 及它的所有组件吗？
+UninstallOnlyOnWin64=这个安装程序只能在64位Windows中进行卸载。
+OnlyAdminCanUninstall=这个安装的程序需要有管理员权限的用户才能卸载。
+UninstallStatusLabel=正在从您的电脑中删除 %1，请稍等。
+UninstalledAll=%1 已顺利地从您的电脑中删除。
+UninstalledMost=%1 卸载完成。%n%n有一些内容无法被删除。您可以手动删除它们。
+UninstalledAndNeedsRestart=要完成 %1 的卸载，您的电脑必须重新启动。%n%n您想立即重新启动电脑吗？
+UninstallDataCorrupted=文件“%1”已损坏，无法卸载
+
+; *** 卸载状态消息
+ConfirmDeleteSharedFileTitle=删除共享文件吗？
+ConfirmDeleteSharedFile2=系统中包含的下列共享文件已经不再被其它程序使用。您想要卸载程序删除这些共享文件吗？%n%n如果这些文件被删除，但还有程序正在使用这些文件，这些程序可能不能正确执行。如果您不能确定，选择“否”。把这些文件保留在系统中以免引起问题。
+SharedFileNameLabel=文件名：
+SharedFileLocationLabel=位置：
+WizardUninstalling=卸载状态
+StatusUninstalling=正在卸载 %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=正在安装 %1。
+ShutdownBlockReasonUninstallingApp=正在卸载 %1。
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 版本 %2
+AdditionalIcons=附加快捷方式：
+CreateDesktopIcon=创建桌面快捷方式(&D)
+CreateQuickLaunchIcon=创建快速运行栏快捷方式(&Q)
+ProgramOnTheWeb=%1 网站
+UninstallProgram=卸载 %1
+LaunchProgram=运行 %1
+AssocFileExtension=将 %2 文件扩展名与 %1 建立关联(&A)
+AssocingFileExtension=正在将 %2 文件扩展名与 %1 建立关联...
+AutoStartProgramGroupDescription=启动组：
+AutoStartProgram=自动启动 %1
+AddonHostProgramNotFound=%1无法找到您所选择的文件夹。%n%n您想要继续吗？

--- a/deploy/languages/Default.isl
+++ b/deploy/languages/Default.isl
@@ -1,0 +1,384 @@
+﻿; *** Inno Setup version 6.1.0+ English messages ***
+;
+; To download user-contributed translations of this file, go to:
+;   https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and 
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=English
+LanguageID=$0409
+LanguageCodePage=0
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=8
+;WelcomeFontName=Verdana
+;WelcomeFontSize=12
+;TitleFontName=Arial
+;TitleFontSize=29
+;CopyrightFontName=Arial
+;CopyrightFontSize=8
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=Setup
+SetupWindowTitle=Setup - %1
+UninstallAppTitle=Uninstall
+UninstallAppFullTitle=%1 Uninstall
+
+; *** Misc. common
+InformationTitle=Information
+ConfirmTitle=Confirm
+ErrorTitle=Error
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=This will install %1. Do you wish to continue?
+LdrCannotCreateTemp=Unable to create a temporary file. Setup aborted
+LdrCannotExecTemp=Unable to execute file in the temporary directory. Setup aborted
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1.%n%nError %2: %3
+SetupFileMissing=The file %1 is missing from the installation directory. Please correct the problem or obtain a new copy of the program.
+SetupFileCorrupt=The setup files are corrupted. Please obtain a new copy of the program.
+SetupFileCorruptOrWrongVer=The setup files are corrupted, or are incompatible with this version of Setup. Please correct the problem or obtain a new copy of the program.
+InvalidParameter=An invalid parameter was passed on the command line:%n%n%1
+SetupAlreadyRunning=Setup is already running.
+WindowsVersionNotSupported=This program does not support the version of Windows your computer is running.
+WindowsServicePackRequired=This program requires %1 Service Pack %2 or later.
+NotOnThisPlatform=This program will not run on %1.
+OnlyOnThisPlatform=This program must be run on %1.
+OnlyOnTheseArchitectures=This program can only be installed on versions of Windows designed for the following processor architectures:%n%n%1
+WinVersionTooLowError=This program requires %1 version %2 or later.
+WinVersionTooHighError=This program cannot be installed on %1 version %2 or later.
+AdminPrivilegesRequired=You must be logged in as an administrator when installing this program.
+PowerUserPrivilegesRequired=You must be logged in as an administrator or as a member of the Power Users group when installing this program.
+SetupAppRunningError=Setup has detected that %1 is currently running.%n%nPlease close all instances of it now, then click OK to continue, or Cancel to exit.
+UninstallAppRunningError=Uninstall has detected that %1 is currently running.%n%nPlease close all instances of it now, then click OK to continue, or Cancel to exit.
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=Select Setup Install Mode
+PrivilegesRequiredOverrideInstruction=Select install mode
+PrivilegesRequiredOverrideText1=%1 can be installed for all users (requires administrative privileges), or for you only.
+PrivilegesRequiredOverrideText2=%1 can be installed for you only, or for all users (requires administrative privileges).
+PrivilegesRequiredOverrideAllUsers=Install for &all users
+PrivilegesRequiredOverrideAllUsersRecommended=Install for &all users (recommended)
+PrivilegesRequiredOverrideCurrentUser=Install for &me only
+PrivilegesRequiredOverrideCurrentUserRecommended=Install for &me only (recommended)
+
+; *** Misc. errors
+ErrorCreatingDir=Setup was unable to create the directory "%1"
+ErrorTooManyFilesInDir=Unable to create a file in the directory "%1" because it contains too many files
+
+; *** Setup common messages
+ExitSetupTitle=Exit Setup
+ExitSetupMessage=Setup is not complete. If you exit now, the program will not be installed.%n%nYou may run Setup again at another time to complete the installation.%n%nExit Setup?
+AboutSetupMenuItem=&About Setup...
+AboutSetupTitle=About Setup
+AboutSetupMessage=%1 version %2%n%3%n%n%1 home page:%n%4
+AboutSetupNote=
+TranslatorNote=
+
+; *** Buttons
+ButtonBack=< &Back
+ButtonNext=&Next >
+ButtonInstall=&Install
+ButtonOK=OK
+ButtonCancel=Cancel
+ButtonYes=&Yes
+ButtonYesToAll=Yes to &All
+ButtonNo=&No
+ButtonNoToAll=N&o to All
+ButtonFinish=&Finish
+ButtonBrowse=&Browse...
+ButtonWizardBrowse=B&rowse...
+ButtonNewFolder=&Make New Folder
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=Select Setup Language
+SelectLanguageLabel=Select the language to use during the installation.
+
+; *** Common wizard text
+ClickNext=Click Next to continue, or Cancel to exit Setup.
+BeveledLabel=
+BrowseDialogTitle=Browse For Folder
+BrowseDialogLabel=Select a folder in the list below, then click OK.
+NewFolderName=New Folder
+
+; *** "Welcome" wizard page
+WelcomeLabel1=Welcome to the [name] Setup Wizard
+WelcomeLabel2=This will install [name/ver] on your computer.%n%nIt is recommended that you close all other applications before continuing.
+
+; *** "Password" wizard page
+WizardPassword=Password
+PasswordLabel1=This installation is password protected.
+PasswordLabel3=Please provide the password, then click Next to continue. Passwords are case-sensitive.
+PasswordEditLabel=&Password:
+IncorrectPassword=The password you entered is not correct. Please try again.
+
+; *** "License Agreement" wizard page
+WizardLicense=License Agreement
+LicenseLabel=Please read the following important information before continuing.
+LicenseLabel3=Please read the following License Agreement. You must accept the terms of this agreement before continuing with the installation.
+LicenseAccepted=I &accept the agreement
+LicenseNotAccepted=I &do not accept the agreement
+
+; *** "Information" wizard pages
+WizardInfoBefore=Information
+InfoBeforeLabel=Please read the following important information before continuing.
+InfoBeforeClickLabel=When you are ready to continue with Setup, click Next.
+WizardInfoAfter=Information
+InfoAfterLabel=Please read the following important information before continuing.
+InfoAfterClickLabel=When you are ready to continue with Setup, click Next.
+
+; *** "User Information" wizard page
+WizardUserInfo=User Information
+UserInfoDesc=Please enter your information.
+UserInfoName=&User Name:
+UserInfoOrg=&Organization:
+UserInfoSerial=&Serial Number:
+UserInfoNameRequired=You must enter a name.
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=Select Destination Location
+SelectDirDesc=Where should [name] be installed?
+SelectDirLabel3=Setup will install [name] into the following folder.
+SelectDirBrowseLabel=To continue, click Next. If you would like to select a different folder, click Browse.
+DiskSpaceGBLabel=At least [gb] GB of free disk space is required.
+DiskSpaceMBLabel=At least [mb] MB of free disk space is required.
+CannotInstallToNetworkDrive=Setup cannot install to a network drive.
+CannotInstallToUNCPath=Setup cannot install to a UNC path.
+InvalidPath=You must enter a full path with drive letter; for example:%n%nC:\APP%n%nor a UNC path in the form:%n%n\\server\share
+InvalidDrive=The drive or UNC share you selected does not exist or is not accessible. Please select another.
+DiskSpaceWarningTitle=Not Enough Disk Space
+DiskSpaceWarning=Setup requires at least %1 KB of free space to install, but the selected drive only has %2 KB available.%n%nDo you want to continue anyway?
+DirNameTooLong=The folder name or path is too long.
+InvalidDirName=The folder name is not valid.
+BadDirName32=Folder names cannot include any of the following characters:%n%n%1
+DirExistsTitle=Folder Exists
+DirExists=The folder:%n%n%1%n%nalready exists. Would you like to install to that folder anyway?
+DirDoesntExistTitle=Folder Does Not Exist
+DirDoesntExist=The folder:%n%n%1%n%ndoes not exist. Would you like the folder to be created?
+
+; *** "Select Components" wizard page
+WizardSelectComponents=Select Components
+SelectComponentsDesc=Which components should be installed?
+SelectComponentsLabel2=Select the components you want to install; clear the components you do not want to install. Click Next when you are ready to continue.
+FullInstallation=Full installation
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=Compact installation
+CustomInstallation=Custom installation
+NoUninstallWarningTitle=Components Exist
+NoUninstallWarning=Setup has detected that the following components are already installed on your computer:%n%n%1%n%nDeselecting these components will not uninstall them.%n%nWould you like to continue anyway?
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=Current selection requires at least [gb] GB of disk space.
+ComponentsDiskSpaceMBLabel=Current selection requires at least [mb] MB of disk space.
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=Select Additional Tasks
+SelectTasksDesc=Which additional tasks should be performed?
+SelectTasksLabel2=Select the additional tasks you would like Setup to perform while installing [name], then click Next.
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=Select Start Menu Folder
+SelectStartMenuFolderDesc=Where should Setup place the program's shortcuts?
+SelectStartMenuFolderLabel3=Setup will create the program's shortcuts in the following Start Menu folder.
+SelectStartMenuFolderBrowseLabel=To continue, click Next. If you would like to select a different folder, click Browse.
+MustEnterGroupName=You must enter a folder name.
+GroupNameTooLong=The folder name or path is too long.
+InvalidGroupName=The folder name is not valid.
+BadGroupName=The folder name cannot include any of the following characters:%n%n%1
+NoProgramGroupCheck2=&Don't create a Start Menu folder
+
+; *** "Ready to Install" wizard page
+WizardReady=Ready to Install
+ReadyLabel1=Setup is now ready to begin installing [name] on your computer.
+ReadyLabel2a=Click Install to continue with the installation, or click Back if you want to review or change any settings.
+ReadyLabel2b=Click Install to continue with the installation.
+ReadyMemoUserInfo=User information:
+ReadyMemoDir=Destination location:
+ReadyMemoType=Setup type:
+ReadyMemoComponents=Selected components:
+ReadyMemoGroup=Start Menu folder:
+ReadyMemoTasks=Additional tasks:
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel=Downloading additional files...
+ButtonStopDownload=&Stop download
+StopDownload=Are you sure you want to stop the download?
+ErrorDownloadAborted=Download aborted
+ErrorDownloadFailed=Download failed: %1 %2
+ErrorDownloadSizeFailed=Getting size failed: %1 %2
+ErrorFileHash1=File hash failed: %1
+ErrorFileHash2=Invalid file hash: expected %1, found %2
+ErrorProgress=Invalid progress: %1 of %2
+ErrorFileSize=Invalid file size: expected %1, found %2
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=Preparing to Install
+PreparingDesc=Setup is preparing to install [name] on your computer.
+PreviousInstallNotCompleted=The installation/removal of a previous program was not completed. You will need to restart your computer to complete that installation.%n%nAfter restarting your computer, run Setup again to complete the installation of [name].
+CannotContinue=Setup cannot continue. Please click Cancel to exit.
+ApplicationsFound=The following applications are using files that need to be updated by Setup. It is recommended that you allow Setup to automatically close these applications.
+ApplicationsFound2=The following applications are using files that need to be updated by Setup. It is recommended that you allow Setup to automatically close these applications. After the installation has completed, Setup will attempt to restart the applications.
+CloseApplications=&Automatically close the applications
+DontCloseApplications=&Do not close the applications
+ErrorCloseApplications=Setup was unable to automatically close all applications. It is recommended that you close all applications using files that need to be updated by Setup before continuing.
+PrepareToInstallNeedsRestart=Setup must restart your computer. After restarting your computer, run Setup again to complete the installation of [name].%n%nWould you like to restart now?
+
+; *** "Installing" wizard page
+WizardInstalling=Installing
+InstallingLabel=Please wait while Setup installs [name] on your computer.
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=Completing the [name] Setup Wizard
+FinishedLabelNoIcons=Setup has finished installing [name] on your computer.
+FinishedLabel=Setup has finished installing [name] on your computer. The application may be launched by selecting the installed shortcuts.
+ClickFinish=Click Finish to exit Setup.
+FinishedRestartLabel=To complete the installation of [name], Setup must restart your computer. Would you like to restart now?
+FinishedRestartMessage=To complete the installation of [name], Setup must restart your computer.%n%nWould you like to restart now?
+ShowReadmeCheck=Yes, I would like to view the README file
+YesRadio=&Yes, restart the computer now
+NoRadio=&No, I will restart the computer later
+; used for example as 'Run MyProg.exe'
+RunEntryExec=Run %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=View %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=Setup Needs the Next Disk
+SelectDiskLabel2=Please insert Disk %1 and click OK.%n%nIf the files on this disk can be found in a folder other than the one displayed below, enter the correct path or click Browse.
+PathLabel=&Path:
+FileNotInDir2=The file "%1" could not be located in "%2". Please insert the correct disk or select another folder.
+SelectDirectoryLabel=Please specify the location of the next disk.
+
+; *** Installation phase messages
+SetupAborted=Setup was not completed.%n%nPlease correct the problem and run Setup again.
+AbortRetryIgnoreSelectAction=Select action
+AbortRetryIgnoreRetry=&Try again
+AbortRetryIgnoreIgnore=&Ignore the error and continue
+AbortRetryIgnoreCancel=Cancel installation
+
+; *** Installation status messages
+StatusClosingApplications=Closing applications...
+StatusCreateDirs=Creating directories...
+StatusExtractFiles=Extracting files...
+StatusCreateIcons=Creating shortcuts...
+StatusCreateIniEntries=Creating INI entries...
+StatusCreateRegistryEntries=Creating registry entries...
+StatusRegisterFiles=Registering files...
+StatusSavingUninstall=Saving uninstall information...
+StatusRunProgram=Finishing installation...
+StatusRestartingApplications=Restarting applications...
+StatusRollback=Rolling back changes...
+
+; *** Misc. errors
+ErrorInternal2=Internal error: %1
+ErrorFunctionFailedNoCode=%1 failed
+ErrorFunctionFailed=%1 failed; code %2
+ErrorFunctionFailedWithMessage=%1 failed; code %2.%n%3
+ErrorExecutingProgram=Unable to execute file:%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=Error opening registry key:%n%1\%2
+ErrorRegCreateKey=Error creating registry key:%n%1\%2
+ErrorRegWriteKey=Error writing to registry key:%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=Error creating INI entry in file "%1".
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=&Skip this file (not recommended)
+FileAbortRetryIgnoreIgnoreNotRecommended=&Ignore the error and continue (not recommended)
+SourceIsCorrupted=The source file is corrupted
+SourceDoesntExist=The source file "%1" does not exist
+ExistingFileReadOnly2=The existing file could not be replaced because it is marked read-only.
+ExistingFileReadOnlyRetry=&Remove the read-only attribute and try again
+ExistingFileReadOnlyKeepExisting=&Keep the existing file
+ErrorReadingExistingDest=An error occurred while trying to read the existing file:
+FileExistsSelectAction=Select action
+FileExists2=The file already exists.
+FileExistsOverwriteExisting=&Overwrite the existing file
+FileExistsKeepExisting=&Keep the existing file
+FileExistsOverwriteOrKeepAll=&Do this for the next conflicts
+ExistingFileNewerSelectAction=Select action
+ExistingFileNewer2=The existing file is newer than the one Setup is trying to install.
+ExistingFileNewerOverwriteExisting=&Overwrite the existing file
+ExistingFileNewerKeepExisting=&Keep the existing file (recommended)
+ExistingFileNewerOverwriteOrKeepAll=&Do this for the next conflicts
+ErrorChangingAttr=An error occurred while trying to change the attributes of the existing file:
+ErrorCreatingTemp=An error occurred while trying to create a file in the destination directory:
+ErrorReadingSource=An error occurred while trying to read the source file:
+ErrorCopying=An error occurred while trying to copy a file:
+ErrorReplacingExistingFile=An error occurred while trying to replace the existing file:
+ErrorRestartReplace=RestartReplace failed:
+ErrorRenamingTemp=An error occurred while trying to rename a file in the destination directory:
+ErrorRegisterServer=Unable to register the DLL/OCX: %1
+ErrorRegSvr32Failed=RegSvr32 failed with exit code %1
+ErrorRegisterTypeLib=Unable to register the type library: %1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32-bit
+UninstallDisplayNameMark64Bit=64-bit
+UninstallDisplayNameMarkAllUsers=All users
+UninstallDisplayNameMarkCurrentUser=Current user
+
+; *** Post-installation errors
+ErrorOpeningReadme=An error occurred while trying to open the README file.
+ErrorRestartingComputer=Setup was unable to restart the computer. Please do this manually.
+
+; *** Uninstaller messages
+UninstallNotFound=File "%1" does not exist. Cannot uninstall.
+UninstallOpenError=File "%1" could not be opened. Cannot uninstall
+UninstallUnsupportedVer=The uninstall log file "%1" is in a format not recognized by this version of the uninstaller. Cannot uninstall
+UninstallUnknownEntry=An unknown entry (%1) was encountered in the uninstall log
+ConfirmUninstall=Are you sure you want to completely remove %1 and all of its components?
+UninstallOnlyOnWin64=This installation can only be uninstalled on 64-bit Windows.
+OnlyAdminCanUninstall=This installation can only be uninstalled by a user with administrative privileges.
+UninstallStatusLabel=Please wait while %1 is removed from your computer.
+UninstalledAll=%1 was successfully removed from your computer.
+UninstalledMost=%1 uninstall complete.%n%nSome elements could not be removed. These can be removed manually.
+UninstalledAndNeedsRestart=To complete the uninstallation of %1, your computer must be restarted.%n%nWould you like to restart now?
+UninstallDataCorrupted="%1" file is corrupted. Cannot uninstall
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=Remove Shared File?
+ConfirmDeleteSharedFile2=The system indicates that the following shared file is no longer in use by any programs. Would you like for Uninstall to remove this shared file?%n%nIf any programs are still using this file and it is removed, those programs may not function properly. If you are unsure, choose No. Leaving the file on your system will not cause any harm.
+SharedFileNameLabel=File name:
+SharedFileLocationLabel=Location:
+WizardUninstalling=Uninstall Status
+StatusUninstalling=Uninstalling %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=Installing %1.
+ShutdownBlockReasonUninstallingApp=Uninstalling %1.
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 version %2
+AdditionalIcons=Additional shortcuts:
+CreateDesktopIcon=Create a &desktop shortcut
+CreateQuickLaunchIcon=Create a &Quick Launch shortcut
+ProgramOnTheWeb=%1 on the Web
+UninstallProgram=Uninstall %1
+LaunchProgram=Launch %1
+AssocFileExtension=&Associate %1 with the %2 file extension
+AssocingFileExtension=Associating %1 with the %2 file extension...
+AutoStartProgramGroupDescription=Startup:
+AutoStartProgram=Automatically start %1
+AddonHostProgramNotFound=%1 could not be located in the folder you selected.%n%nDo you want to continue anyway?

--- a/deploy/languages/French.isl
+++ b/deploy/languages/French.isl
@@ -1,0 +1,404 @@
+﻿; *** Inno Setup version 6.1.0+ French messages ***
+;
+; To download user-contributed translations of this file, go to:
+;   https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+;
+; Maintained by Pierre Yager (pierre@levosgien.net)
+;
+; Contributors : Frédéric Bonduelle, Francis Pallini, Lumina, Pascal Peyrot
+;
+; Changes :
+; + Accents on uppercase letters
+;      http://www.academie-francaise.fr/langue/questions.html#accentuation (lumina)
+; + Typography quotes [see ISBN: 978-2-7433-0482-9]
+;      http://fr.wikipedia.org/wiki/Guillemet (lumina)
+; + Binary units (Kio, Mio) [IEC 80000-13:2008]
+;      http://fr.wikipedia.org/wiki/Octet (lumina)
+; + Reverted to standard units (Ko, Mo) to follow Windows Explorer Standard
+;      http://blogs.msdn.com/b/oldnewthing/archive/2009/06/11/9725386.aspx
+; + Use more standard verbs for click and retry
+;     "click": "Clicker" instead of "Appuyer" 
+;     "retry": "Recommencer" au lieu de "Réessayer"
+; + Added new 6.0.0 messages
+; + Added new 6.1.0 messages
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and 
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=Français
+LanguageID=$040C
+LanguageCodePage=1252
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=8
+;WelcomeFontName=Verdana
+;WelcomeFontSize=12
+;TitleFontName=Arial
+;TitleFontSize=29
+;CopyrightFontName=Arial
+;CopyrightFontSize=8
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=Installation
+SetupWindowTitle=Installation - %1
+UninstallAppTitle=Désinstallation
+UninstallAppFullTitle=Désinstallation - %1
+
+; *** Misc. common
+InformationTitle=Information
+ConfirmTitle=Confirmation
+ErrorTitle=Erreur
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=Cet assistant va installer %1. Voulez-vous continuer ?
+LdrCannotCreateTemp=Impossible de créer un fichier temporaire. Abandon de l'installation
+LdrCannotExecTemp=Impossible d'exécuter un fichier depuis le dossier temporaire. Abandon de l'installation
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1.%n%nErreur %2 : %3
+SetupFileMissing=Le fichier %1 est absent du dossier d'installation. Veuillez corriger le problème ou vous procurer une nouvelle copie du programme.
+SetupFileCorrupt=Les fichiers d'installation sont altérés. Veuillez vous procurer une nouvelle copie du programme.
+SetupFileCorruptOrWrongVer=Les fichiers d'installation sont altérés ou ne sont pas compatibles avec cette version de l'assistant d'installation. Veuillez corriger le problème ou vous procurer une nouvelle copie du programme.
+InvalidParameter=Un paramètre non valide a été passé à la ligne de commande :%n%n%1
+SetupAlreadyRunning=L'assistant d'installation est déjà en cours d'exécution.
+WindowsVersionNotSupported=Ce programme n'est pas prévu pour fonctionner avec la version de Windows utilisée sur votre ordinateur.
+WindowsServicePackRequired=Ce programme a besoin de %1 Service Pack %2 ou d'une version plus récente.
+NotOnThisPlatform=Ce programme ne fonctionne pas sous %1.
+OnlyOnThisPlatform=Ce programme ne peut fonctionner que sous %1.
+OnlyOnTheseArchitectures=Ce programme ne peut être installé que sur des versions de Windows qui supportent ces architectures : %n%n%1
+WinVersionTooLowError=Ce programme requiert la version %2 ou supérieure de %1.
+WinVersionTooHighError=Ce programme ne peut pas être installé sous %1 version %2 ou supérieure.
+AdminPrivilegesRequired=Vous devez disposer des droits d'administration de cet ordinateur pour installer ce programme.
+PowerUserPrivilegesRequired=Vous devez disposer des droits d'administration ou faire partie du groupe « Utilisateurs avec pouvoir » de cet ordinateur pour installer ce programme.
+SetupAppRunningError=L'assistant d'installation a détecté que %1 est actuellement en cours d'exécution.%n%nVeuillez fermer toutes les instances de cette application puis cliquer sur OK pour continuer, ou bien cliquer sur Annuler pour abandonner l'installation.
+UninstallAppRunningError=La procédure de désinstallation a détecté que %1 est actuellement en cours d'exécution.%n%nVeuillez fermer toutes les instances de cette application  puis cliquer sur OK pour continuer, ou bien cliquer sur Annuler pour abandonner la désinstallation.
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=Choix du Mode d'Installation
+PrivilegesRequiredOverrideInstruction=Choisissez le mode d'installation
+PrivilegesRequiredOverrideText1=%1 peut être installé pour tous les utilisateurs (nécessite des privilèges administrateur), ou seulement pour vous.
+PrivilegesRequiredOverrideText2=%1 peut-être installé seulement pour vous, ou pour tous les utilisateurs (nécessite des privilèges administrateur).
+PrivilegesRequiredOverrideAllUsers=Installer pour &tous les utilisateurs
+PrivilegesRequiredOverrideAllUsersRecommended=Installer pour &tous les utilisateurs (recommandé)
+PrivilegesRequiredOverrideCurrentUser=Installer seulement pour &moi
+PrivilegesRequiredOverrideCurrentUserRecommended=Installer seulement pour &moi (recommandé)
+
+; *** Misc. errors
+ErrorCreatingDir=L'assistant d'installation n'a pas pu créer le dossier "%1"
+ErrorTooManyFilesInDir=L'assistant d'installation n'a pas pu créer un fichier dans le dossier "%1" car celui-ci contient trop de fichiers
+
+; *** Setup common messages
+ExitSetupTitle=Quitter l'installation
+ExitSetupMessage=L'installation n'est pas terminée. Si vous abandonnez maintenant, le programme ne sera pas installé.%n%nVous devrez relancer cet assistant pour finir l'installation.%n%nVoulez-vous quand même quitter l'assistant d'installation ?
+AboutSetupMenuItem=À &propos...
+AboutSetupTitle=À Propos de l'assistant d'installation
+AboutSetupMessage=%1 version %2%n%3%n%nPage d'accueil de %1 :%n%4
+AboutSetupNote=
+TranslatorNote=Traduction française maintenue par Pierre Yager (pierre@levosgien.net)
+
+; *** Buttons
+ButtonBack=< &Précédent
+ButtonNext=&Suivant >
+ButtonInstall=&Installer
+ButtonOK=OK
+ButtonCancel=Annuler
+ButtonYes=&Oui
+ButtonYesToAll=Oui pour &tout
+ButtonNo=&Non
+ButtonNoToAll=N&on pour tout
+ButtonFinish=&Terminer
+ButtonBrowse=Pa&rcourir...
+ButtonWizardBrowse=Pa&rcourir...
+ButtonNewFolder=Nouveau &dossier
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=Langue de l'assistant d'installation
+SelectLanguageLabel=Veuillez sélectionner la langue qui sera utilisée par l'assistant d'installation.
+
+; *** Common wizard text
+ClickNext=Cliquez sur Suivant pour continuer ou sur Annuler pour abandonner l'installation.
+BeveledLabel=
+BrowseDialogTitle=Parcourir les dossiers
+BrowseDialogLabel=Veuillez choisir un dossier de destination, puis cliquez sur OK.
+NewFolderName=Nouveau dossier
+
+; *** "Welcome" wizard page
+WelcomeLabel1=Bienvenue dans l'assistant d'installation de [name]
+WelcomeLabel2=Cet assistant va vous guider dans l'installation de [name/ver] sur votre ordinateur.%n%nIl est recommandé de fermer toutes les applications actives avant de continuer.
+
+; *** "Password" wizard page
+WizardPassword=Mot de passe
+PasswordLabel1=Cette installation est protégée par un mot de passe.
+PasswordLabel3=Veuillez saisir le mot de passe (attention à la distinction entre majuscules et minuscules) puis cliquez sur Suivant pour continuer.
+PasswordEditLabel=&Mot de passe :
+IncorrectPassword=Le mot de passe saisi n'est pas valide. Veuillez essayer à nouveau.
+
+; *** "License Agreement" wizard page
+WizardLicense=Accord de licence
+LicenseLabel=Les informations suivantes sont importantes. Veuillez les lire avant de continuer.
+LicenseLabel3=Veuillez lire le contrat de licence suivant. Vous devez en accepter tous les termes avant de continuer l'installation.
+LicenseAccepted=Je comprends et j'&accepte les termes du contrat de licence
+LicenseNotAccepted=Je &refuse les termes du contrat de licence
+
+; *** "Information" wizard pages
+WizardInfoBefore=Information
+InfoBeforeLabel=Les informations suivantes sont importantes. Veuillez les lire avant de continuer.
+InfoBeforeClickLabel=Lorsque vous êtes prêt à continuer, cliquez sur Suivant.
+WizardInfoAfter=Information
+InfoAfterLabel=Les informations suivantes sont importantes. Veuillez les lire avant de continuer.
+InfoAfterClickLabel=Lorsque vous êtes prêt à continuer, cliquez sur Suivant.
+
+; *** "User Information" wizard page
+WizardUserInfo=Informations sur l'Utilisateur
+UserInfoDesc=Veuillez saisir les informations qui vous concernent.
+UserInfoName=&Nom d'utilisateur :
+UserInfoOrg=&Organisation :
+UserInfoSerial=Numéro de &série :
+UserInfoNameRequired=Vous devez au moins saisir un nom.
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=Dossier de destination
+SelectDirDesc=Où [name] doit-il être installé ?
+SelectDirLabel3=L'assistant va installer [name] dans le dossier suivant.
+SelectDirBrowseLabel=Pour continuer, cliquez sur Suivant. Si vous souhaitez choisir un dossier différent, cliquez sur Parcourir.
+DiskSpaceGBLabel=Le programme requiert au moins [gb] Go d'espace disque disponible.
+DiskSpaceMBLabel=Le programme requiert au moins [mb] Mo d'espace disque disponible.
+CannotInstallToNetworkDrive=L'assistant ne peut pas installer sur un disque réseau.
+CannotInstallToUNCPath=L'assistant ne peut pas installer sur un chemin UNC.
+InvalidPath=Vous devez saisir un chemin complet avec sa lettre de lecteur ; par exemple :%n%nC:\APP%n%nou un chemin réseau de la forme :%n%n\\serveur\partage
+InvalidDrive=L'unité ou l'emplacement réseau que vous avez sélectionné n'existe pas ou n'est pas accessible. Veuillez choisir une autre destination.
+DiskSpaceWarningTitle=Espace disponible insuffisant
+DiskSpaceWarning=L'assistant a besoin d'au moins %1 Ko d'espace disponible pour effectuer l'installation, mais l'unité que vous avez sélectionnée ne dispose que de %2 Ko d'espace disponible.%n%nSouhaitez-vous continuer malgré tout ?
+DirNameTooLong=Le nom ou le chemin du dossier est trop long.
+InvalidDirName=Le nom du dossier est invalide.
+BadDirName32=Le nom du dossier ne doit contenir aucun des caractères suivants :%n%n%1
+DirExistsTitle=Dossier existant
+DirExists=Le dossier :%n%n%1%n%nexiste déjà. Souhaitez-vous installer dans ce dossier malgré tout ?
+DirDoesntExistTitle=Le dossier n'existe pas
+DirDoesntExist=Le dossier %n%n%1%n%nn'existe pas. Souhaitez-vous que ce dossier soit créé ?
+
+; *** "Select Components" wizard page
+WizardSelectComponents=Composants à installer
+SelectComponentsDesc=Quels composants de l'application souhaitez-vous installer ?
+SelectComponentsLabel2=Sélectionnez les composants que vous désirez installer ; décochez les composants que vous ne désirez pas installer. Cliquez ensuite sur Suivant pour continuer l'installation.
+FullInstallation=Installation complète
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=Installation compacte
+CustomInstallation=Installation personnalisée
+NoUninstallWarningTitle=Composants existants
+NoUninstallWarning=L'assistant d'installation a détecté que les composants suivants sont déjà installés sur votre système :%n%n%1%n%nDésélectionner ces composants ne les désinstallera pas pour autant.%n%nVoulez-vous continuer malgré tout ?
+ComponentSize1=%1 Ko
+ComponentSize2=%1 Mo
+ComponentsDiskSpaceGBLabel=Les composants sélectionnés nécessitent au moins [gb] Go d'espace disponible.
+ComponentsDiskSpaceMBLabel=Les composants sélectionnés nécessitent au moins [mb] Mo d'espace disponible.
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=Tâches supplémentaires
+SelectTasksDesc=Quelles sont les tâches supplémentaires qui doivent être effectuées ?
+SelectTasksLabel2=Sélectionnez les tâches supplémentaires que l'assistant d'installation doit effectuer pendant l'installation de [name], puis cliquez sur Suivant.
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=Sélection du dossier du menu Démarrer
+SelectStartMenuFolderDesc=Où l'assistant d'installation doit-il placer les raccourcis du programme ?
+SelectStartMenuFolderLabel3=L'assistant va créer les raccourcis du programme dans le dossier du menu Démarrer indiqué ci-dessous.
+SelectStartMenuFolderBrowseLabel=Cliquez sur Suivant pour continuer. Cliquez sur Parcourir si vous souhaitez sélectionner un autre dossier du menu Démarrer.
+MustEnterGroupName=Vous devez saisir un nom de dossier du menu Démarrer.
+GroupNameTooLong=Le nom ou le chemin du dossier est trop long.
+InvalidGroupName=Le nom du dossier n'est pas valide.
+BadGroupName=Le nom du dossier ne doit contenir aucun des caractères suivants :%n%n%1
+NoProgramGroupCheck2=Ne pas créer de &dossier dans le menu Démarrer
+
+; *** "Ready to Install" wizard page
+WizardReady=Prêt à installer
+ReadyLabel1=L'assistant dispose à présent de toutes les informations pour installer [name] sur votre ordinateur.
+ReadyLabel2a=Cliquez sur Installer pour procéder à l'installation ou sur Précédent pour revoir ou modifier une option d'installation.
+ReadyLabel2b=Cliquez sur Installer pour procéder à l'installation.
+ReadyMemoUserInfo=Informations sur l'utilisateur :
+ReadyMemoDir=Dossier de destination :
+ReadyMemoType=Type d'installation :
+ReadyMemoComponents=Composants sélectionnés :
+ReadyMemoGroup=Dossier du menu Démarrer :
+ReadyMemoTasks=Tâches supplémentaires :
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel=Téléchargement de fichiers supplémentaires...
+ButtonStopDownload=&Arrêter le téléchargement
+StopDownload=Êtes-vous sûr de vouloir arrêter le téléchargement ?
+ErrorDownloadAborted=Téléchargement annulé
+ErrorDownloadFailed=Le téléchargement a échoué : %1 %2
+ErrorDownloadSizeFailed=La récupération de la taille du fichier a échouée : %1 %2
+ErrorFileHash1=Le calcul de l'empreinte du fichier a échoué : %1
+ErrorFileHash2=Empreinte du fichier invalide : attendue %1, trouvée %2
+ErrorProgress=Progression invalide : %1 sur %2
+ErrorFileSize=Taille du fichier invalide : attendue %1, trouvée %2
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=Préparation de l'installation
+PreparingDesc=L'assistant d'installation prépare l'installation de [name] sur votre ordinateur.
+PreviousInstallNotCompleted=L'installation ou la suppression d'un programme précédent n'est pas totalement achevée. Veuillez redémarrer votre ordinateur pour achever cette installation ou suppression.%n%nUne fois votre ordinateur redémarré, veuillez relancer cet assistant pour reprendre l'installation de [name].
+CannotContinue=L'assistant ne peut pas continuer. Veuillez cliquer sur Annuler pour abandonner l'installation.
+ApplicationsFound=Les applications suivantes utilisent des fichiers qui doivent être mis à jour par l'assistant. Il est recommandé d'autoriser l'assistant à fermer ces applications automatiquement.
+ApplicationsFound2=Les applications suivantes utilisent des fichiers qui doivent être mis à jour par l'assistant. Il est recommandé d'autoriser l'assistant à fermer ces applications automatiquement. Une fois l'installation terminée, l'assistant essaiera de relancer ces applications.
+CloseApplications=&Arrêter les applications automatiquement
+DontCloseApplications=&Ne pas arrêter les applications
+ErrorCloseApplications=L'assistant d'installation n'a pas pu arrêter toutes les applications automatiquement. Nous vous recommandons de fermer toutes les applications qui utilisent des fichiers devant être mis à jour par l'assistant d'installation avant de continuer.
+PrepareToInstallNeedsRestart=L'assistant d'installation doit redémarrer votre ordinateur. Une fois votre ordinateur redémarré, veuillez relancer cet assistant d'installation pour terminer l'installation de [name].%n%nVoulez-vous redémarrer votre ordinateur maintenant ?
+
+; *** "Installing" wizard page
+WizardInstalling=Installation en cours
+InstallingLabel=Veuillez patienter pendant que l'assistant installe [name] sur votre ordinateur.
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=Fin de l'installation de [name]
+FinishedLabelNoIcons=L'assistant a terminé l'installation de [name] sur votre ordinateur.
+FinishedLabel=L'assistant a terminé l'installation de [name] sur votre ordinateur. L'application peut être lancée à l'aide des icônes créées sur le Bureau par l'installation.
+ClickFinish=Veuillez cliquer sur Terminer pour quitter l'assistant d'installation.
+FinishedRestartLabel=L'assistant doit redémarrer votre ordinateur pour terminer l'installation de [name].%n%nVoulez-vous redémarrer maintenant ?
+FinishedRestartMessage=L'assistant doit redémarrer votre ordinateur pour terminer l'installation de [name].%n%nVoulez-vous redémarrer maintenant ?
+ShowReadmeCheck=Oui, je souhaite lire le fichier LISEZMOI
+YesRadio=&Oui, redémarrer mon ordinateur maintenant
+NoRadio=&Non, je préfère redémarrer mon ordinateur plus tard
+; used for example as 'Run MyProg.exe'
+RunEntryExec=Exécuter %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=Voir %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=L'assistant a besoin du disque suivant
+SelectDiskLabel2=Veuillez insérer le disque %1 et cliquer sur OK.%n%nSi les fichiers de ce disque se trouvent à un emplacement différent de celui indiqué ci-dessous, veuillez saisir le chemin correspondant ou cliquez sur Parcourir.
+PathLabel=&Chemin :
+FileNotInDir2=Le fichier "%1" ne peut pas être trouvé dans "%2". Veuillez insérer le bon disque ou sélectionner un autre dossier.
+SelectDirectoryLabel=Veuillez indiquer l'emplacement du disque suivant.
+
+; *** Installation phase messages
+SetupAborted=L'installation n'est pas terminée.%n%nVeuillez corriger le problème et relancer l'installation.
+AbortRetryIgnoreSelectAction=Choisissez une action
+AbortRetryIgnoreRetry=&Recommencer
+AbortRetryIgnoreIgnore=&Ignorer l'erreur et continuer
+AbortRetryIgnoreCancel=Annuler l'installation
+
+; *** Installation status messages
+StatusClosingApplications=Ferme les applications...
+StatusCreateDirs=Création des dossiers...
+StatusExtractFiles=Extraction des fichiers...
+StatusCreateIcons=Création des raccourcis...
+StatusCreateIniEntries=Création des entrées du fichier INI...
+StatusCreateRegistryEntries=Création des entrées de registre...
+StatusRegisterFiles=Enregistrement des fichiers...
+StatusSavingUninstall=Sauvegarde des informations de désinstallation...
+StatusRunProgram=Finalisation de l'installation...
+StatusRestartingApplications=Relance les applications...
+StatusRollback=Annulation des modifications...
+
+; *** Misc. errors
+ErrorInternal2=Erreur interne : %1
+ErrorFunctionFailedNoCode=%1 a échoué
+ErrorFunctionFailed=%1 a échoué ; code %2
+ErrorFunctionFailedWithMessage=%1 a échoué ; code %2.%n%3
+ErrorExecutingProgram=Impossible d'exécuter le fichier :%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=Erreur lors de l'ouverture de la clé de registre :%n%1\%2
+ErrorRegCreateKey=Erreur lors de la création de la clé de registre :%n%1\%2
+ErrorRegWriteKey=Erreur lors de l'écriture de la clé de registre :%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=Erreur d'écriture d'une entrée dans le fichier INI "%1".
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=&Ignorer ce fichier (non recommandé)
+FileAbortRetryIgnoreIgnoreNotRecommended=&Ignorer l'erreur et continuer (non recommandé)
+SourceIsCorrupted=Le fichier source est altéré
+SourceDoesntExist=Le fichier source "%1" n'existe pas
+ExistingFileReadOnly2=Le fichier existant ne peut pas être remplacé parce qu'il est protégé par l'attribut lecture seule.
+ExistingFileReadOnlyRetry=&Supprimer l'attribut lecture seule et réessayer
+ExistingFileReadOnlyKeepExisting=&Conserver le fichier existant
+ErrorReadingExistingDest=Une erreur s'est produite lors de la tentative de lecture du fichier existant :
+FileExistsSelectAction=Choisissez une action
+FileExists2=Le fichier existe déjà.
+FileExistsOverwriteExisting=&Ecraser le fichier existant
+FileExistsKeepExisting=&Conserver le fichier existant
+FileExistsOverwriteOrKeepAll=&Faire ceci pour les conflits à venir
+ExistingFileNewerSelectAction=Choisissez une action
+ExistingFileNewer2=Le fichier existant est plus récent que celui que l'assistant d'installation est en train d'installer.
+ExistingFileNewerOverwriteExisting=&Ecraser le fichier existant
+ExistingFileNewerKeepExisting=&Conserver le fichier existant (recommandé)
+ExistingFileNewerOverwriteOrKeepAll=&Faire ceci pour les conflits à venir
+ErrorChangingAttr=Une erreur est survenue en essayant de modifier les attributs du fichier existant :
+ErrorCreatingTemp=Une erreur est survenue en essayant de créer un fichier dans le dossier de destination :
+ErrorReadingSource=Une erreur est survenue lors de la lecture du fichier source :
+ErrorCopying=Une erreur est survenue lors de la copie d'un fichier :
+ErrorReplacingExistingFile=Une erreur est survenue lors du remplacement d'un fichier existant :
+ErrorRestartReplace=Le marquage d'un fichier pour remplacement au redémarrage de l'ordinateur a échoué :
+ErrorRenamingTemp=Une erreur est survenue en essayant de renommer un fichier dans le dossier de destination :
+ErrorRegisterServer=Impossible d'enregistrer la bibliothèque DLL/OCX : %1
+ErrorRegSvr32Failed=RegSvr32 a échoué et a retourné le code d'erreur %1
+ErrorRegisterTypeLib=Impossible d'enregistrer la bibliothèque de type : %1
+
+; *** Nom d'affichage pour la désinstallaton
+; par exemple 'Mon Programme (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; ou par exemple 'Mon Programme (32-bit, Tous les utilisateurs)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32-bit
+UninstallDisplayNameMark64Bit=64-bit
+UninstallDisplayNameMarkAllUsers=Tous les utilisateurs
+UninstallDisplayNameMarkCurrentUser=Utilisateur courant
+
+; *** Post-installation errors
+ErrorOpeningReadme=Une erreur est survenue à l'ouverture du fichier LISEZMOI.
+ErrorRestartingComputer=L'installation n'a pas pu redémarrer l'ordinateur. Merci de bien vouloir le faire vous-même.
+
+; *** Uninstaller messages
+UninstallNotFound=Le fichier "%1" n'existe pas. Impossible de désinstaller.
+UninstallOpenError=Le fichier "%1" n'a pas pu être ouvert. Impossible de désinstaller
+UninstallUnsupportedVer=Le format du fichier journal de désinstallation "%1" n'est pas reconnu par cette version de la procédure de désinstallation. Impossible de désinstaller
+UninstallUnknownEntry=Une entrée inconnue (%1) a été rencontrée dans le fichier journal de désinstallation
+ConfirmUninstall=Voulez-vous vraiment désinstaller complètement %1 ainsi que tous ses composants ?
+UninstallOnlyOnWin64=La désinstallation de ce programme ne fonctionne qu'avec une version 64 bits de Windows.
+OnlyAdminCanUninstall=Ce programme ne peut être désinstallé que par un utilisateur disposant des droits d'administration.
+UninstallStatusLabel=Veuillez patienter pendant que %1 est retiré de votre ordinateur.
+UninstalledAll=%1 a été correctement désinstallé de cet ordinateur.
+UninstalledMost=La désinstallation de %1 est terminée.%n%nCertains éléments n'ont pas pu être supprimés automatiquement. Vous pouvez les supprimer manuellement.
+UninstalledAndNeedsRestart=Vous devez redémarrer l'ordinateur pour terminer la désinstallation de %1.%n%nVoulez-vous redémarrer maintenant ?
+UninstallDataCorrupted=Le ficher "%1" est altéré. Impossible de désinstaller
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=Supprimer les fichiers partagés ?
+ConfirmDeleteSharedFile2=Le système indique que le fichier partagé suivant n'est plus utilisé par aucun programme. Souhaitez-vous que la désinstallation supprime ce fichier partagé ?%n%nSi des programmes utilisent encore ce fichier et qu'il est supprimé, ces programmes ne pourront plus fonctionner correctement. Si vous n'êtes pas sûr, choisissez Non. Laisser ce fichier dans votre système ne posera pas de problème.
+SharedFileNameLabel=Nom du fichier :
+SharedFileLocationLabel=Emplacement :
+WizardUninstalling=État de la désinstallation
+StatusUninstalling=Désinstallation de %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=Installe %1.
+ShutdownBlockReasonUninstallingApp=Désinstalle %1.
+
+; Les messages personnalisés suivants ne sont pas utilisé par l'installation
+; elle-même, mais si vous les utilisez dans vos scripts, vous devez les
+; traduire
+
+[CustomMessages]
+
+NameAndVersion=%1 version %2
+AdditionalIcons=Icônes supplémentaires :
+CreateDesktopIcon=Créer une icône sur le &Bureau
+CreateQuickLaunchIcon=Créer une icône dans la barre de &Lancement rapide
+ProgramOnTheWeb=Page d'accueil de %1
+UninstallProgram=Désinstaller %1
+LaunchProgram=Exécuter %1
+AssocFileExtension=&Associer %1 avec l'extension de fichier %2
+AssocingFileExtension=Associe %1 avec l'extension de fichier %2...
+AutoStartProgramGroupDescription=Démarrage :
+AutoStartProgram=Démarrer automatiquement %1
+AddonHostProgramNotFound=%1 n'a pas été trouvé dans le dossier que vous avez choisi.%n%nVoulez-vous continuer malgré tout ?

--- a/deploy/languages/German.isl
+++ b/deploy/languages/German.isl
@@ -1,0 +1,406 @@
+﻿; ******************************************************
+; ***                                                ***
+; *** Inno Setup version 6.1.0+ German messages      ***
+; ***                                                ***
+; *** Changes 6.0.0+ Author:                         ***
+; ***                                                ***
+; ***   Jens Brand (jens.brand@wolf-software.de)     ***
+; ***                                                ***
+; *** Original Authors:                              ***
+; ***                                                ***
+; ***   Peter Stadler (Peter.Stadler@univie.ac.at)   ***
+; ***   Michael Reitz (innosetup@assimilate.de)      ***
+; ***                                                ***
+; *** Contributors:                                  ***
+; ***                                                ***
+; ***   Roland Ruder (info@rr4u.de)                  ***
+; ***   Hans Sperber (Hans.Sperber@de.bosch.com)     ***
+; ***   LaughingMan (puma.d@web.de)                  ***
+; ***                                                ***
+; ******************************************************
+;
+; Diese Übersetzung hält sich an die neue deutsche Rechtschreibung.
+
+; To download user-contributed translations of this file, go to:
+; https://jrsoftware.org/files/istrans/
+
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and 
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=Deutsch
+LanguageID=$0407
+LanguageCodePage=1252
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=8
+;WelcomeFontName=Verdana
+;WelcomeFontSize=12
+;TitleFontName=Arial
+;TitleFontSize=29
+;CopyrightFontName=Arial
+;CopyrightFontSize=8
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=Setup
+SetupWindowTitle=Setup - %1
+UninstallAppTitle=Entfernen
+UninstallAppFullTitle=%1 entfernen
+
+; *** Misc. common
+InformationTitle=Information
+ConfirmTitle=Bestätigen
+ErrorTitle=Fehler
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=%1 wird jetzt installiert. Möchten Sie fortfahren?
+LdrCannotCreateTemp=Es konnte keine temporäre Datei erstellt werden. Das Setup wurde abgebrochen
+LdrCannotExecTemp=Die Datei konnte nicht im temporären Ordner ausgeführt werden. Das Setup wurde abgebrochen
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1.%n%nFehler %2: %3
+SetupFileMissing=Die Datei %1 fehlt im Installationsordner. Bitte beheben Sie das Problem oder besorgen Sie sich eine neue Kopie des Programms.
+SetupFileCorrupt=Die Setup-Dateien sind beschädigt. Besorgen Sie sich bitte eine neue Kopie des Programms.
+SetupFileCorruptOrWrongVer=Die Setup-Dateien sind beschädigt oder inkompatibel zu dieser Version des Setups. Bitte beheben Sie das Problem oder besorgen Sie sich eine neue Kopie des Programms.
+InvalidParameter=Ein ungültiger Parameter wurde auf der Kommandozeile übergeben:%n%n%1
+SetupAlreadyRunning=Setup läuft bereits.
+WindowsVersionNotSupported=Dieses Programm unterstützt die auf Ihrem Computer installierte Windows-Version nicht.
+WindowsServicePackRequired=Dieses Programm benötigt %1 Service Pack %2 oder höher.
+NotOnThisPlatform=Dieses Programm kann nicht unter %1 ausgeführt werden.
+OnlyOnThisPlatform=Dieses Programm muss unter %1 ausgeführt werden.
+OnlyOnTheseArchitectures=Dieses Programm kann nur auf Windows-Versionen installiert werden, die folgende Prozessor-Architekturen unterstützen:%n%n%1
+WinVersionTooLowError=Dieses Programm benötigt %1 Version %2 oder höher.
+WinVersionTooHighError=Dieses Programm kann nicht unter %1 Version %2 oder höher installiert werden.
+AdminPrivilegesRequired=Sie müssen als Administrator angemeldet sein, um dieses Programm installieren zu können.
+PowerUserPrivilegesRequired=Sie müssen als Administrator oder als Mitglied der Hauptbenutzer-Gruppe angemeldet sein, um dieses Programm installieren zu können.
+SetupAppRunningError=Das Setup hat entdeckt, dass %1 zurzeit ausgeführt wird.%n%nBitte schließen Sie jetzt alle laufenden Instanzen und klicken Sie auf "OK", um fortzufahren, oder auf "Abbrechen", um zu beenden.
+UninstallAppRunningError=Die Deinstallation hat entdeckt, dass %1 zurzeit ausgeführt wird.%n%nBitte schließen Sie jetzt alle laufenden Instanzen und klicken Sie auf "OK", um fortzufahren, oder auf "Abbrechen", um zu beenden.
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=Installationsmodus auswählen
+PrivilegesRequiredOverrideInstruction=Bitte wählen Sie den Installationsmodus
+PrivilegesRequiredOverrideText1=%1 kann für alle Benutzer (erfordert Administrationsrechte) oder nur für Sie installiert werden.
+PrivilegesRequiredOverrideText2=%1 kann nur für Sie oder für alle Benutzer (erfordert Administrationsrechte) installiert werden.
+PrivilegesRequiredOverrideAllUsers=Installation für &alle Benutzer
+PrivilegesRequiredOverrideAllUsersRecommended=Installation für &alle Benutzer (empfohlen)
+PrivilegesRequiredOverrideCurrentUser=Installation nur für &Sie
+PrivilegesRequiredOverrideCurrentUserRecommended=Installation nur für &Sie (empfohlen)
+
+; *** Misc. errors
+ErrorCreatingDir=Das Setup konnte den Ordner "%1" nicht erstellen.
+ErrorTooManyFilesInDir=Das Setup konnte eine Datei im Ordner "%1" nicht erstellen, weil er zu viele Dateien enthält.
+
+; *** Setup common messages
+ExitSetupTitle=Setup verlassen
+ExitSetupMessage=Das Setup ist noch nicht abgeschlossen. Wenn Sie jetzt beenden, wird das Programm nicht installiert.%n%nSie können das Setup zu einem späteren Zeitpunkt nochmals ausführen, um die Installation zu vervollständigen.%n%nSetup verlassen?
+AboutSetupMenuItem=&Über das Setup ...
+AboutSetupTitle=Über das Setup
+AboutSetupMessage=%1 Version %2%n%3%n%n%1 Webseite:%n%4
+AboutSetupNote=
+TranslatorNote=German translation maintained by Jens Brand (jens.brand@wolf-software.de)
+
+; *** Buttons
+ButtonBack=< &Zurück
+ButtonNext=&Weiter >
+ButtonInstall=&Installieren
+ButtonOK=OK
+ButtonCancel=Abbrechen
+ButtonYes=&Ja
+ButtonYesToAll=J&a für Alle
+ButtonNo=&Nein
+ButtonNoToAll=N&ein für Alle
+ButtonFinish=&Fertigstellen
+ButtonBrowse=&Durchsuchen ...
+ButtonWizardBrowse=Du&rchsuchen ...
+ButtonNewFolder=&Neuen Ordner erstellen
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=Setup-Sprache auswählen
+SelectLanguageLabel=Wählen Sie die Sprache aus, die während der Installation benutzt werden soll:
+
+; *** Common wizard text
+ClickNext="Weiter" zum Fortfahren, "Abbrechen" zum Verlassen.
+BeveledLabel=
+BrowseDialogTitle=Ordner suchen
+BrowseDialogLabel=Wählen Sie einen Ordner aus und klicken Sie danach auf "OK".
+NewFolderName=Neuer Ordner
+
+; *** "Welcome" wizard page
+WelcomeLabel1=Willkommen zum [name] Setup-Assistenten
+WelcomeLabel2=Dieser Assistent wird jetzt [name/ver] auf Ihrem Computer installieren.%n%nSie sollten alle anderen Anwendungen beenden, bevor Sie mit dem Setup fortfahren.
+
+; *** "Password" wizard page
+WizardPassword=Passwort
+PasswordLabel1=Diese Installation wird durch ein Passwort geschützt.
+PasswordLabel3=Bitte geben Sie das Passwort ein und klicken Sie danach auf "Weiter". Achten Sie auf korrekte Groß-/Kleinschreibung.
+PasswordEditLabel=&Passwort:
+IncorrectPassword=Das eingegebene Passwort ist nicht korrekt. Bitte versuchen Sie es noch einmal.
+
+; *** "License Agreement" wizard page
+WizardLicense=Lizenzvereinbarung
+LicenseLabel=Lesen Sie bitte folgende wichtige Informationen, bevor Sie fortfahren.
+LicenseLabel3=Lesen Sie bitte die folgenden Lizenzvereinbarungen. Benutzen Sie bei Bedarf die Bildlaufleiste oder drücken Sie die "Bild Ab"-Taste.
+LicenseAccepted=Ich &akzeptiere die Vereinbarung
+LicenseNotAccepted=Ich &lehne die Vereinbarung ab
+
+; *** "Information" wizard pages
+WizardInfoBefore=Information
+InfoBeforeLabel=Lesen Sie bitte folgende wichtige Informationen, bevor Sie fortfahren.
+InfoBeforeClickLabel=Klicken Sie auf "Weiter", sobald Sie bereit sind, mit dem Setup fortzufahren.
+WizardInfoAfter=Information
+InfoAfterLabel=Lesen Sie bitte folgende wichtige Informationen, bevor Sie fortfahren.
+InfoAfterClickLabel=Klicken Sie auf "Weiter", sobald Sie bereit sind, mit dem Setup fortzufahren.
+
+; *** "User Information" wizard page
+WizardUserInfo=Benutzerinformationen
+UserInfoDesc=Bitte tragen Sie Ihre Daten ein.
+UserInfoName=&Name:
+UserInfoOrg=&Organisation:
+UserInfoSerial=&Seriennummer:
+UserInfoNameRequired=Sie müssen einen Namen eintragen.
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=Ziel-Ordner wählen
+SelectDirDesc=Wohin soll [name] installiert werden?
+SelectDirLabel3=Das Setup wird [name] in den folgenden Ordner installieren.
+SelectDirBrowseLabel=Klicken Sie auf "Weiter", um fortzufahren. Klicken Sie auf "Durchsuchen", falls Sie einen anderen Ordner auswählen möchten.
+DiskSpaceGBLabel=Mindestens [gb] GB freier Speicherplatz ist erforderlich.
+DiskSpaceMBLabel=Mindestens [mb] MB freier Speicherplatz ist erforderlich.
+CannotInstallToNetworkDrive=Das Setup kann nicht in einen Netzwerk-Pfad installieren.
+CannotInstallToUNCPath=Das Setup kann nicht in einen UNC-Pfad installieren. Wenn Sie auf ein Netzlaufwerk installieren möchten, müssen Sie dem Netzwerkpfad einen Laufwerksbuchstaben zuordnen.
+InvalidPath=Sie müssen einen vollständigen Pfad mit einem Laufwerksbuchstaben angeben, z. B.:%n%nC:\Beispiel%n%noder einen UNC-Pfad in der Form:%n%n\\Server\Freigabe
+InvalidDrive=Das angegebene Laufwerk bzw. der UNC-Pfad existiert nicht oder es kann nicht darauf zugegriffen werden. Wählen Sie bitte einen anderen Ordner.
+DiskSpaceWarningTitle=Nicht genug freier Speicherplatz
+DiskSpaceWarning=Das Setup benötigt mindestens %1 KB freien Speicherplatz zum Installieren, aber auf dem ausgewählten Laufwerk sind nur %2 KB verfügbar.%n%nMöchten Sie trotzdem fortfahren?
+DirNameTooLong=Der Ordnername/Pfad ist zu lang.
+InvalidDirName=Der Ordnername ist nicht gültig.
+BadDirName32=Ordnernamen dürfen keine der folgenden Zeichen enthalten:%n%n%1
+DirExistsTitle=Ordner existiert bereits
+DirExists=Der Ordner:%n%n%1%n%n existiert bereits. Möchten Sie trotzdem in diesen Ordner installieren?
+DirDoesntExistTitle=Ordner ist nicht vorhanden
+DirDoesntExist=Der Ordner:%n%n%1%n%nist nicht vorhanden. Soll der Ordner erstellt werden?
+
+; *** "Select Components" wizard page
+WizardSelectComponents=Komponenten auswählen
+SelectComponentsDesc=Welche Komponenten sollen installiert werden?
+SelectComponentsLabel2=Wählen Sie die Komponenten aus, die Sie installieren möchten. Klicken Sie auf "Weiter", wenn Sie bereit sind, fortzufahren.
+FullInstallation=Vollständige Installation
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=Kompakte Installation
+CustomInstallation=Benutzerdefinierte Installation
+NoUninstallWarningTitle=Komponenten vorhanden
+NoUninstallWarning=Das Setup hat festgestellt, dass die folgenden Komponenten bereits auf Ihrem Computer installiert sind:%n%n%1%n%nDiese nicht mehr ausgewählten Komponenten werden nicht vom Computer entfernt.%n%nMöchten Sie trotzdem fortfahren?
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=Die aktuelle Auswahl erfordert mindestens [gb] GB Speicherplatz.
+ComponentsDiskSpaceMBLabel=Die aktuelle Auswahl erfordert mindestens [mb] MB Speicherplatz.
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=Zusätzliche Aufgaben auswählen
+SelectTasksDesc=Welche zusätzlichen Aufgaben sollen ausgeführt werden?
+SelectTasksLabel2=Wählen Sie die zusätzlichen Aufgaben aus, die das Setup während der Installation von [name] ausführen soll, und klicken Sie danach auf "Weiter".
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=Startmenü-Ordner auswählen
+SelectStartMenuFolderDesc=Wo soll das Setup die Programm-Verknüpfungen erstellen?
+SelectStartMenuFolderLabel3=Das Setup wird die Programm-Verknüpfungen im folgenden Startmenü-Ordner erstellen.
+SelectStartMenuFolderBrowseLabel=Klicken Sie auf "Weiter", um fortzufahren. Klicken Sie auf "Durchsuchen", falls Sie einen anderen Ordner auswählen möchten.
+MustEnterGroupName=Sie müssen einen Ordnernamen eingeben.
+GroupNameTooLong=Der Ordnername/Pfad ist zu lang.
+InvalidGroupName=Der Ordnername ist nicht gültig.
+BadGroupName=Der Ordnername darf keine der folgenden Zeichen enthalten:%n%n%1
+NoProgramGroupCheck2=&Keinen Ordner im Startmenü erstellen
+
+; *** "Ready to Install" wizard page
+WizardReady=Bereit zur Installation.
+ReadyLabel1=Das Setup ist jetzt bereit, [name] auf Ihrem Computer zu installieren.
+ReadyLabel2a=Klicken Sie auf "Installieren", um mit der Installation zu beginnen, oder auf "Zurück", um Ihre Einstellungen zu überprüfen oder zu ändern.
+ReadyLabel2b=Klicken Sie auf "Installieren", um mit der Installation zu beginnen.
+ReadyMemoUserInfo=Benutzerinformationen:
+ReadyMemoDir=Ziel-Ordner:
+ReadyMemoType=Setup-Typ:
+ReadyMemoComponents=Ausgewählte Komponenten:
+ReadyMemoGroup=Startmenü-Ordner:
+ReadyMemoTasks=Zusätzliche Aufgaben:
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel=Lade zusätzliche Dateien herunter...
+ButtonStopDownload=Download &abbrechen
+StopDownload=Sind Sie sicher, dass Sie den Download abbrechen wollen?
+ErrorDownloadAborted=Download abgebrochen
+ErrorDownloadFailed=Download fehlgeschlagen: %1 %2
+ErrorDownloadSizeFailed=Fehler beim Ermitteln der Größe: %1 %2
+ErrorFileHash1=Fehler beim Ermitteln der Datei-Prüfsumme: %1
+ErrorFileHash2=Ungültige Datei-Prüfsumme: erwartet %1, gefunden %2
+ErrorProgress=Ungültiger Fortschritt: %1 von %2
+ErrorFileSize=Ungültige Dateigröße: erwartet %1, gefunden %2
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=Vorbereitung der Installation
+PreparingDesc=Das Setup bereitet die Installation von [name] auf diesem Computer vor.
+PreviousInstallNotCompleted=Eine vorherige Installation/Deinstallation eines Programms wurde nicht abgeschlossen. Der Computer muss neu gestartet werden, um die Installation/Deinstallation zu beenden.%n%nStarten Sie das Setup nach dem Neustart Ihres Computers erneut, um die Installation von [name] durchzuführen.
+CannotContinue=Das Setup kann nicht fortfahren. Bitte klicken Sie auf "Abbrechen" zum Verlassen.
+ApplicationsFound=Die folgenden Anwendungen benutzen Dateien, die aktualisiert werden müssen. Es wird empfohlen, Setup zu erlauben, diese Anwendungen zu schließen.
+ApplicationsFound2=Die folgenden Anwendungen benutzen Dateien, die aktualisiert werden müssen. Es wird empfohlen, Setup zu erlauben, diese Anwendungen zu schließen. Nachdem die Installation fertiggestellt wurde, versucht Setup, diese Anwendungen wieder zu starten.
+CloseApplications=&Schließe die Anwendungen automatisch
+DontCloseApplications=Schließe die A&nwendungen nicht
+ErrorCloseApplications=Das Setup konnte nicht alle Anwendungen automatisch schließen. Es wird empfohlen, alle Anwendungen zu schließen, die Dateien benutzen, die vom Setup vor einer Fortsetzung aktualisiert werden müssen.  
+PrepareToInstallNeedsRestart=Das Setup muss Ihren Computer neu starten. Führen Sie nach dem Neustart Setup erneut aus, um die Installation von [name] abzuschließen.%n%nWollen Sie jetzt neu starten? 
+
+; *** "Installing" wizard page
+WizardInstalling=Installiere ...
+InstallingLabel=Warten Sie bitte, während [name] auf Ihrem Computer installiert wird.
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=Beenden des [name] Setup-Assistenten
+FinishedLabelNoIcons=Das Setup hat die Installation von [name] auf Ihrem Computer abgeschlossen.
+FinishedLabel=Das Setup hat die Installation von [name] auf Ihrem Computer abgeschlossen. Die Anwendung kann über die installierten Programm-Verknüpfungen gestartet werden.
+ClickFinish=Klicken Sie auf "Fertigstellen", um das Setup zu beenden.
+FinishedRestartLabel=Um die Installation von [name] abzuschließen, muss das Setup Ihren Computer neu starten. Möchten Sie jetzt neu starten?
+FinishedRestartMessage=Um die Installation von [name] abzuschließen, muss das Setup Ihren Computer neu starten.%n%nMöchten Sie jetzt neu starten?
+ShowReadmeCheck=Ja, ich möchte die LIESMICH-Datei sehen
+YesRadio=&Ja, Computer jetzt neu starten
+NoRadio=&Nein, ich werde den Computer später neu starten
+; used for example as 'Run MyProg.exe'
+RunEntryExec=%1 starten
+; used for example as 'View Readme.txt'
+RunEntryShellExec=%1 anzeigen
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=Nächsten Datenträger einlegen
+SelectDiskLabel2=Legen Sie bitte Datenträger %1 ein und klicken Sie auf "OK".%n%nWenn sich die Dateien von diesem Datenträger in einem anderen als dem angezeigten Ordner befinden, dann geben Sie bitte den korrekten Pfad ein oder klicken auf "Durchsuchen".
+PathLabel=&Pfad:
+FileNotInDir2=Die Datei "%1" befindet sich nicht in "%2". Bitte Ordner ändern oder richtigen Datenträger einlegen.
+SelectDirectoryLabel=Geben Sie bitte an, wo der nächste Datenträger eingelegt wird.
+
+; *** Installation phase messages
+SetupAborted=Das Setup konnte nicht abgeschlossen werden.%n%nBeheben Sie bitte das Problem und starten Sie das Setup erneut.
+AbortRetryIgnoreSelectAction=Bitte auswählen
+AbortRetryIgnoreRetry=&Nochmals versuchen
+AbortRetryIgnoreIgnore=&Den Fehler ignorieren und fortfahren
+AbortRetryIgnoreCancel=Installation abbrechen
+
+; *** Installation status messages
+StatusClosingApplications=Anwendungen werden geschlossen ...
+StatusCreateDirs=Ordner werden erstellt ...
+StatusExtractFiles=Dateien werden entpackt ...
+StatusCreateIcons=Verknüpfungen werden erstellt ...
+StatusCreateIniEntries=INI-Einträge werden erstellt ...
+StatusCreateRegistryEntries=Registry-Einträge werden erstellt ...
+StatusRegisterFiles=Dateien werden registriert ...
+StatusSavingUninstall=Deinstallationsinformationen werden gespeichert ...
+StatusRunProgram=Installation wird beendet ...
+StatusRestartingApplications=Neustart der Anwendungen ...
+StatusRollback=Änderungen werden rückgängig gemacht ...
+
+; *** Misc. errors
+ErrorInternal2=Interner Fehler: %1
+ErrorFunctionFailedNoCode=%1 schlug fehl
+ErrorFunctionFailed=%1 schlug fehl; Code %2
+ErrorFunctionFailedWithMessage=%1 schlug fehl; Code %2.%n%3
+ErrorExecutingProgram=Datei kann nicht ausgeführt werden:%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=Registry-Schlüssel konnte nicht geöffnet werden:%n%1\%2
+ErrorRegCreateKey=Registry-Schlüssel konnte nicht erstellt werden:%n%1\%2
+ErrorRegWriteKey=Fehler beim Schreiben des Registry-Schlüssels:%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=Fehler beim Erstellen eines INI-Eintrages in der Datei "%1".
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=Diese Datei &überspringen (nicht empfohlen)
+FileAbortRetryIgnoreIgnoreNotRecommended=Den Fehler &ignorieren und fortfahren (nicht empfohlen)
+SourceIsCorrupted=Die Quelldatei ist beschädigt
+SourceDoesntExist=Die Quelldatei "%1" existiert nicht
+ExistingFileReadOnly2=Die vorhandene Datei kann nicht ersetzt werden, da sie schreibgeschützt ist.
+ExistingFileReadOnlyRetry=&Den Schreibschutz entfernen und noch einmal versuchen
+ExistingFileReadOnlyKeepExisting=Die &vorhandene Datei behalten
+ErrorReadingExistingDest=Lesefehler in Datei:
+FileExistsSelectAction=Aktion auswählen
+FileExists2=Die Datei ist bereits vorhanden.
+FileExistsOverwriteExisting=Vorhandene Datei &überschreiben
+FileExistsKeepExisting=Vorhandene Datei &behalten
+FileExistsOverwriteOrKeepAll=&Dies auch für die nächsten Konflikte ausführen
+ExistingFileNewerSelectAction=Aktion auswählen
+ExistingFileNewer2=Die vorhandene Datei ist neuer als die Datei, die installiert werden soll.
+ExistingFileNewerOverwriteExisting=Vorhandene Datei &überschreiben
+ExistingFileNewerKeepExisting=Vorhandene Datei &behalten (empfohlen)
+ExistingFileNewerOverwriteOrKeepAll=&Dies auch für die nächsten Konflikte ausführen
+ErrorChangingAttr=Fehler beim Ändern der Datei-Attribute:
+ErrorCreatingTemp=Fehler beim Erstellen einer Datei im Ziel-Ordner:
+ErrorReadingSource=Fehler beim Lesen der Quelldatei:
+ErrorCopying=Fehler beim Kopieren einer Datei:
+ErrorReplacingExistingFile=Fehler beim Ersetzen einer vorhandenen Datei:
+ErrorRestartReplace="Ersetzen nach Neustart" fehlgeschlagen:
+ErrorRenamingTemp=Fehler beim Umbenennen einer Datei im Ziel-Ordner:
+ErrorRegisterServer=DLL/OCX konnte nicht registriert werden: %1
+ErrorRegSvr32Failed=RegSvr32-Aufruf scheiterte mit Exit-Code %1
+ErrorRegisterTypeLib=Typen-Bibliothek konnte nicht registriert werden: %1
+
+; *** Uninstall display name markings
+; used for example as 'Mein Programm (32 Bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'Mein Programm (32 Bit, Alle Benutzer)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32 Bit
+UninstallDisplayNameMark64Bit=64 Bit
+UninstallDisplayNameMarkAllUsers=Alle Benutzer
+UninstallDisplayNameMarkCurrentUser=Aktueller Benutzer
+
+; *** Post-installation errors
+ErrorOpeningReadme=Fehler beim Öffnen der LIESMICH-Datei.
+ErrorRestartingComputer=Das Setup konnte den Computer nicht neu starten. Bitte führen Sie den Neustart manuell durch.
+
+; *** Uninstaller messages
+UninstallNotFound=Die Datei "%1" existiert nicht. Entfernen der Anwendung fehlgeschlagen.
+UninstallOpenError=Die Datei "%1" konnte nicht geöffnet werden. Entfernen der Anwendung fehlgeschlagen.
+UninstallUnsupportedVer=Das Format der Deinstallationsdatei "%1" konnte nicht erkannt werden. Entfernen der Anwendung fehlgeschlagen.
+UninstallUnknownEntry=In der Deinstallationsdatei wurde ein unbekannter Eintrag (%1) gefunden.
+ConfirmUninstall=Sind Sie sicher, dass Sie %1 und alle zugehörigen Komponenten entfernen möchten?
+UninstallOnlyOnWin64=Diese Installation kann nur unter 64-Bit-Windows-Versionen entfernt werden.
+OnlyAdminCanUninstall=Diese Installation kann nur von einem Benutzer mit Administrator-Rechten entfernt werden.
+UninstallStatusLabel=Warten Sie bitte, während %1 von Ihrem Computer entfernt wird.
+UninstalledAll=%1 wurde erfolgreich von Ihrem Computer entfernt.
+UninstalledMost=Entfernen von %1 beendet.%n%nEinige Komponenten konnten nicht entfernt werden. Diese können von Ihnen manuell gelöscht werden.
+UninstalledAndNeedsRestart=Um die Deinstallation von %1 abzuschließen, muss Ihr Computer neu gestartet werden.%n%nMöchten Sie jetzt neu starten?
+UninstallDataCorrupted="%1"-Datei ist beschädigt. Entfernen der Anwendung fehlgeschlagen.
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=Gemeinsame Datei entfernen?
+ConfirmDeleteSharedFile2=Das System zeigt an, dass die folgende gemeinsame Datei von keinem anderen Programm mehr benutzt wird. Möchten Sie diese Datei entfernen lassen?%nSollte es doch noch Programme geben, die diese Datei benutzen und sie wird entfernt, funktionieren diese Programme vielleicht nicht mehr richtig. Wenn Sie unsicher sind, wählen Sie "Nein", um die Datei im System zu belassen. Es schadet Ihrem System nicht, wenn Sie die Datei behalten.
+SharedFileNameLabel=Dateiname:
+SharedFileLocationLabel=Ordner:
+WizardUninstalling=Entfernen (Status)
+StatusUninstalling=Entferne %1 ...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=Installation von %1.
+ShutdownBlockReasonUninstallingApp=Deinstallation von %1.
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 Version %2
+AdditionalIcons=Zusätzliche Symbole:
+CreateDesktopIcon=&Desktop-Symbol erstellen
+CreateQuickLaunchIcon=Symbol in der Schnellstartleiste erstellen
+ProgramOnTheWeb=%1 im Internet
+UninstallProgram=%1 entfernen
+LaunchProgram=%1 starten
+AssocFileExtension=&Registriere %1 mit der %2-Dateierweiterung
+AssocingFileExtension=%1 wird mit der %2-Dateierweiterung registriert...
+AutoStartProgramGroupDescription=Beginn des Setups:
+AutoStartProgram=Starte automatisch%1
+AddonHostProgramNotFound=%1 konnte im ausgewählten Ordner nicht gefunden werden.%n%nMöchten Sie dennoch fortfahren?
+

--- a/deploy/languages/Italian.isl
+++ b/deploy/languages/Italian.isl
@@ -1,0 +1,390 @@
+﻿; bovirus@gmail.com
+; *** Inno Setup version 6.1.0+ Italian messages ***
+;
+; To download user-contributed translations of this file, go to:
+;    https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+;
+; Italian.isl - Last Update: 25.07.2020  by bovirus (bovirus@gmail.com)
+;
+; Translator name:   bovirus
+; Translator e-mail: bovirus@gmail.com
+; Based on previous translations of Rinaldo M. aka Whiteshark (based on ale5000 5.1.11+ translation)
+;
+[LangOptions]
+; The following three entries are very important. Be sure to read and 
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=Italiano
+LanguageID=$0410
+LanguageCodePage=1252
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=8
+;WelcomeFontName=Verdana
+;WelcomeFontSize=12
+;TitleFontName=Arial
+;TitleFontSize=29
+;CopyrightFontName=Arial
+;CopyrightFontSize=8
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=Installazione
+SetupWindowTitle=Installazione di %1
+UninstallAppTitle=Disinstallazione
+UninstallAppFullTitle=Disinstallazione di %1
+
+; *** Misc. common
+InformationTitle=Informazioni
+ConfirmTitle=Conferma
+ErrorTitle=Errore
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=Questa è l'installazione di %1.%n%nVuoi continuare?
+LdrCannotCreateTemp=Impossibile creare un file temporaneo.%n%nInstallazione annullata.
+LdrCannotExecTemp=Impossibile eseguire un file nella cartella temporanea.%n%nInstallazione annullata.
+
+; *** Startup error messages
+LastErrorMessage=%1.%n%nErrore %2: %3
+SetupFileMissing=File %1 non trovato nella cartella di installazione.%n%nCorreggi il problema o richiedi una nuova copia del programma.
+SetupFileCorrupt=I file di installazione sono danneggiati.%n%nRichiedi una nuova copia del programma.
+SetupFileCorruptOrWrongVer=I file di installazione sono danneggiati, o sono incompatibili con questa versione del programma di installazione.%n%nCorreggi il problema o richiedi una nuova copia del programma.
+InvalidParameter=È stato inserito nella riga di comando un parametro non valido:%n%n%1
+SetupAlreadyRunning=Il processo di installazione è già in funzione.
+WindowsVersionNotSupported=Questo programma non supporta la versione di Windows installata nel computer.
+WindowsServicePackRequired=Questo programma richiede %1 Service Pack %2 o successivo.
+NotOnThisPlatform=Questo programma non è compatibile con %1.
+OnlyOnThisPlatform=Questo programma richiede %1.
+OnlyOnTheseArchitectures=Questo programma può essere installato solo su versioni di Windows progettate per le seguenti architetture della CPU:%n%n%1
+WinVersionTooLowError=Questo programma richiede %1 versione %2 o successiva.
+WinVersionTooHighError=Questo programma non può essere installato su %1 versione %2 o successiva.
+AdminPrivilegesRequired=Per installare questo programma sono richiesti privilegi di amministratore.
+PowerUserPrivilegesRequired=Per poter installare questo programma sono richiesti i privilegi di amministratore o di Power Users.
+SetupAppRunningError=%1 è attualmente in esecuzione.%n%nChiudi adesso tutte le istanze del programma e poi seleziona "OK", o seleziona "Annulla" per uscire.
+UninstallAppRunningError=%1 è attualmente in esecuzione.%n%nChiudi adesso tutte le istanze del programma e poi seleziona "OK", o seleziona "Annulla" per uscire.
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=Seleziona modo installazione
+PrivilegesRequiredOverrideInstruction=Seleziona modo installazione
+PrivilegesRequiredOverrideText1=%1 può essere installato per tutti gli utenti (richiede privilegi di amministratore), o solo per l'utente attuale.
+PrivilegesRequiredOverrideText2=%1 può essere installato solo per l'utente attuale, o per tutti gli utenti (richiede privilegi di amministratore).
+PrivilegesRequiredOverrideAllUsers=Inst&alla per tutti gli utenti
+PrivilegesRequiredOverrideAllUsersRecommended=Inst&alla per tutti gli utenti (suggerito)
+PrivilegesRequiredOverrideCurrentUser=Installa solo per l'&utente attuale
+PrivilegesRequiredOverrideCurrentUserRecommended=Installa solo per l'&utente attuale (suggerito)
+
+; *** Misc. errors
+ErrorCreatingDir=Impossibile creare la cartella "%1"
+ErrorTooManyFilesInDir=Impossibile creare i file nella cartella "%1" perché contiene troppi file.
+
+; *** Setup common messages
+ExitSetupTitle=Uscita dall'installazione
+ExitSetupMessage=L'installazione non è completa.%n%nUscendo dall'installazione in questo momento, il programma non sarà installato.%n%nÈ possibile eseguire l'installazione in un secondo tempo.%n%nVuoi uscire dall'installazione?
+AboutSetupMenuItem=&Informazioni sull'installazione...
+AboutSetupTitle=Informazioni sull'installazione
+AboutSetupMessage=%1 versione %2%n%3%n%n%1 sito web:%n%4
+AboutSetupNote=
+TranslatorNote=Traduzione italiana a cura di Rinaldo M. aka Whiteshark e bovirus (v. 11.09.2018)
+
+; *** Buttons
+ButtonBack=< &Indietro
+ButtonNext=&Avanti >
+ButtonInstall=Inst&alla
+ButtonOK=OK
+ButtonCancel=Annulla
+ButtonYes=&Si
+ButtonYesToAll=Sì a &tutto
+ButtonNo=&No
+ButtonNoToAll=N&o a tutto
+ButtonFinish=&Fine
+ButtonBrowse=&Sfoglia...
+ButtonWizardBrowse=S&foglia...
+ButtonNewFolder=&Crea nuova cartella
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=Seleziona la lingua dell'installazione
+SelectLanguageLabel=Seleziona la lingua da usare durante l'installazione.
+
+; *** Common wizard text
+ClickNext=Seleziona "Avanti" per continuare, o "Annulla" per uscire.
+BeveledLabel=
+BrowseDialogTitle=Sfoglia cartelle
+BrowseDialogLabel=Seleziona una cartella nell'elenco, e quindi seleziona "OK".
+NewFolderName=Nuova cartella
+
+; *** "Welcome" wizard page
+WelcomeLabel1=Installazione di [name]
+WelcomeLabel2=[name/ver] sarà installato sul computer.%n%nPrima di procedere chiudi tutte le applicazioni attive.
+
+; *** "Password" wizard page
+WizardPassword=Password
+PasswordLabel1=Questa installazione è protetta da password.
+PasswordLabel3=Inserisci la password, quindi per continuare seleziona "Avanti".%nLe password sono sensibili alle maiuscole/minuscole.
+PasswordEditLabel=&Password:
+IncorrectPassword=La password inserita non è corretta. Riprova.
+
+; *** "License Agreement" wizard page
+WizardLicense=Contratto di licenza
+LicenseLabel=Prima di procedere leggi con attenzione le informazioni che seguono.
+LicenseLabel3=Leggi il seguente contratto di licenza.%nPer procedere con l'installazione è necessario accettare tutti i termini del contratto.
+LicenseAccepted=Accetto i termini del &contratto di licenza 
+LicenseNotAccepted=&Non accetto i termini del contratto di licenza
+
+; *** "Information" wizard pages
+WizardInfoBefore=Informazioni
+InfoBeforeLabel=Prima di procedere leggi le importanti informazioni che seguono.
+InfoBeforeClickLabel=Quando sei pronto per proseguire, seleziona "Avanti".
+WizardInfoAfter=Informazioni
+InfoAfterLabel=Prima di procedere leggi le importanti informazioni che seguono.
+InfoAfterClickLabel=Quando sei pronto per proseguire, seleziona "Avanti".
+
+; *** "User Information" wizard page
+WizardUserInfo=Informazioni utente
+UserInfoDesc=Inserisci le seguenti informazioni.
+UserInfoName=&Nome:
+UserInfoOrg=&Società:
+UserInfoSerial=&Numero di serie:
+UserInfoNameRequired=È necessario inserire un nome.
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=Selezione cartella di installazione
+SelectDirDesc=Dove vuoi installare [name]?
+SelectDirLabel3=[name] sarà installato nella seguente cartella.
+SelectDirBrowseLabel=Per continuare seleziona "Avanti".%nPer scegliere un'altra cartella seleziona "Sfoglia".
+DiskSpaceGBLabel=Sono richiesti almeno [gb] GB di spazio libero nel disco.
+DiskSpaceMBLabel=Sono richiesti almeno [mb] MB di spazio libero nel disco.
+CannotInstallToNetworkDrive=Non è possibile effettuare l'installazione in un disco in rete.
+CannotInstallToUNCPath=Non è possibile effettuare l'installazione in un percorso UNC.
+InvalidPath=Va inserito un percorso completo di lettera di unità; per esempio:%n%nC:\APP%n%no un percorso di rete nella forma:%n%n\\server\condivisione
+InvalidDrive=L'unità o il percorso di rete selezionato non esiste o non è accessibile.%n%nSelezionane un altro.
+DiskSpaceWarningTitle=Spazio su disco insufficiente
+DiskSpaceWarning=L'installazione richiede per eseguire l'installazione almeno %1 KB di spazio libero, ma l'unità selezionata ha solo %2 KB disponibili.%n%nVuoi continuare comunque?
+DirNameTooLong=Il nome della cartella o il percorso sono troppo lunghi.
+InvalidDirName=Il nome della cartella non è valido.
+BadDirName32=Il nome della cartella non può includere nessuno dei seguenti caratteri:%n%n%1
+DirExistsTitle=Cartella già esistente
+DirExists=La cartella%n%n  %1%n%nesiste già.%n%nVuoi comunque installare l'applicazione in questa cartella?
+DirDoesntExistTitle=Cartella inesistente
+DirDoesntExist=La cartella%n%n  %1%n%nnon esiste. Vuoi creare la cartella?
+
+; *** "Select Components" wizard page
+WizardSelectComponents=Selezione componenti
+SelectComponentsDesc=Quali componenti vuoi installare?
+SelectComponentsLabel2=Seleziona i componenti da installare, deseleziona quelli che non vuoi installare.%nPer continuare seleziona "Avanti".
+FullInstallation=Installazione completa
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=Installazione compatta
+CustomInstallation=Installazione personalizzata
+NoUninstallWarningTitle=Componente esistente
+NoUninstallWarning=I seguenti componenti sono già installati nel computer:%n%n%1%n%nDeselezionando questi componenti essi non verranno rimossi.%n%nVuoi continuare comunque?
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=La selezione attuale richiede almeno [gb] GB di spazio nel disco.
+ComponentsDiskSpaceMBLabel=La selezione attuale richiede almeno [mb] MB di spazio nel disco.
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=Selezione processi aggiuntivi
+SelectTasksDesc=Quali processi aggiuntivi vuoi eseguire?
+SelectTasksLabel2=Seleziona i processi aggiuntivi che verranno eseguiti durante l'installazione di [name], quindi seleziona "Avanti".
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=Selezione della cartella nel menu Avvio/Start
+SelectStartMenuFolderDesc=Dove vuoi inserire i collegamenti al programma?
+SelectStartMenuFolderLabel3=Verranno creati i collegamenti al programma nella seguente cartella del menu Avvio/Start.
+SelectStartMenuFolderBrowseLabel=Per continuare, seleziona "Avanti".%nPer selezionare un'altra cartella, seleziona "Sfoglia".
+MustEnterGroupName=Devi inserire il nome della cartella.
+GroupNameTooLong=Il nome della cartella o il percorso sono troppo lunghi.
+InvalidGroupName=Il nome della cartella non è valido.
+BadGroupName=Il nome della cartella non può includere nessuno dei seguenti caratteri:%n%n%1
+NoProgramGroupCheck2=&Non creare una cartella nel menu Avvio/Start
+
+; *** "Ready to Install" wizard page
+WizardReady=Pronto per l'installazione
+ReadyLabel1=Il programma è pronto per iniziare l'installazione di [name] nel computer.
+ReadyLabel2a=Seleziona "Installa" per continuare con l'installazione, o "Indietro" per rivedere o modificare le impostazioni.
+ReadyLabel2b=Per procedere con l'installazione seleziona "Installa".
+ReadyMemoUserInfo=Informazioni utente:
+ReadyMemoDir=Cartella di installazione:
+ReadyMemoType=Tipo di installazione:
+ReadyMemoComponents=Componenti selezionati:
+ReadyMemoGroup=Cartella del menu Avvio/Start:
+ReadyMemoTasks=Processi aggiuntivi:
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel=Download file aggiuntivi...
+ButtonStopDownload=&Stop download
+StopDownload=Sei sicuro di voler interrompere il download?
+ErrorDownloadAborted=Download annullato
+ErrorDownloadFailed=Download fallito: %1 %2
+ErrorDownloadSizeFailed=Rilevamento dimensione fallito: %1 %2
+ErrorFileHash1=Errore hash file: %1
+ErrorFileHash2=Hash file non valido: atteso %1, trovato %2
+ErrorProgress=Progresso non valido: %1 di %2
+ErrorFileSize=Dimensione file non valida: attesa %1, trovata %2
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=Preparazione all'installazione
+PreparingDesc=Preparazione all'installazione di [name] nel computer.
+PreviousInstallNotCompleted=L'installazione/rimozione precedente del programma non è stata completata.%n%nÈ necessario riavviare il sistema per completare l'installazione.%n%nDopo il riavvio del sistema esegui di nuovo l'installazione di [name].
+CannotContinue=L'installazione non può continuare. Seleziona "Annulla" per uscire.
+ApplicationsFound=Le seguenti applicazioni stanno usando file che devono essere aggiornati dall'installazione.%n%nTi consigliamo di permettere al processo di chiudere automaticamente queste applicazioni.
+ApplicationsFound2=Le seguenti applicazioni stanno usando file che devono essere aggiornati dall'installazione.%n%nTi consigliamo di permettere al processo di chiudere automaticamente queste applicazioni.%n%nAl completamento dell'installazione, il processo tenterà di riavviare le applicazioni.
+CloseApplications=Chiudi &automaticamente le applicazioni
+DontCloseApplications=&Non chiudere le applicazioni
+ErrorCloseApplications=L'installazione non è riuscita a chiudere automaticamente tutte le applicazioni.%n%nPrima di proseguire ti raccomandiamo di chiudere tutte le applicazioni che usano file che devono essere aggiornati durante l'installazione.
+PrepareToInstallNeedsRestart=Il programma di installazione deve riavviare il computer.%nDopo aver riavviato il computer esegui di nuovo il programma di installazione per completare l'installazione di [name].%n%nVuoi riavviare il computer ora?
+
+; *** "Installing" wizard page
+WizardInstalling=Installazione in corso
+InstallingLabel=Attendi il completamento dell'installazione di [name] nel computer.
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=Installazione di [name] completata
+FinishedLabelNoIcons=Installazione di [name] completata.
+FinishedLabel=Installazione di [name] completata.%n%nL'applicazione può essere eseguita selezionando le relative icone.
+ClickFinish=Seleziona "Fine" per uscire dall'installazione.
+FinishedRestartLabel=Per completare l'installazione di [name], è necessario riavviare il sistema.%n%nVuoi riavviare adesso?
+FinishedRestartMessage=Per completare l'installazione di [name], è necessario riavviare il sistema.%n%nVuoi riavviare adesso?
+ShowReadmeCheck=Si, visualizza ora il file LEGGIMI
+YesRadio=&Si, riavvia il sistema adesso
+NoRadio=&No, riavvia il sistema più tardi
+; used for example as 'Run MyProg.exe'
+RunEntryExec=Esegui %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=Visualizza %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=L'installazione necessita del disco successivo
+SelectDiskLabel2=Inserisci il disco %1 e seleziona "OK".%n%nSe i file di questo disco si trovano in una cartella diversa da quella visualizzata sotto, inserisci il percorso corretto o seleziona "Sfoglia".
+PathLabel=&Percorso:
+FileNotInDir2=Il file "%1" non è stato trovato in "%2".%n%nInserisci il disco corretto o seleziona un'altra cartella.
+SelectDirectoryLabel=Specifica il percorso del prossimo disco.
+
+; *** Installation phase messages
+SetupAborted=L'installazione non è stata completata.%n%nCorreggi il problema e riesegui nuovamente l'installazione.
+AbortRetryIgnoreSelectAction=Seleziona azione
+AbortRetryIgnoreRetry=&Riprova
+AbortRetryIgnoreIgnore=&Ignora questo errore e continua
+AbortRetryIgnoreCancel=Annulla installazione
+
+; *** Installation status messages
+StatusClosingApplications=Chiusura applicazioni...
+StatusCreateDirs=Creazione cartelle...
+StatusExtractFiles=Estrazione file...
+StatusCreateIcons=Creazione icone...
+StatusCreateIniEntries=Creazione voci nei file INI...
+StatusCreateRegistryEntries=Creazione voci di registro...
+StatusRegisterFiles=Registrazione file...
+StatusSavingUninstall=Salvataggio delle informazioni di disinstallazione...
+StatusRunProgram=Termine dell'installazione...
+StatusRestartingApplications=Riavvio applicazioni...
+StatusRollback=Recupero delle modifiche...
+
+; *** Misc. errors
+ErrorInternal2=Errore interno %1
+ErrorFunctionFailedNoCode=%1 fallito
+ErrorFunctionFailed=%1 fallito; codice %2
+ErrorFunctionFailedWithMessage=%1 fallito; codice %2.%n%3
+ErrorExecutingProgram=Impossibile eseguire il file:%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=Errore di apertura della chiave di registro:%n%1\%2
+ErrorRegCreateKey=Errore di creazione della chiave di registro:%n%1\%2
+ErrorRegWriteKey=Errore di scrittura della chiave di registro:%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=Errore nella creazione delle voci INI nel file "%1".
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=&Salta questo file (non suggerito)
+FileAbortRetryIgnoreIgnoreNotRecommended=&Ignora questo errore e continua (non suggerito)
+SourceIsCorrupted=Il file sorgente è danneggiato
+SourceDoesntExist=Il file sorgente "%1" non esiste
+ExistingFileReadOnly2=Il file esistente non può essere sostituito in quanto segnato come in sola lettura.
+ExistingFileReadOnlyRetry=&Rimuovi attributo di sola lettura e riprova
+ExistingFileReadOnlyKeepExisting=&Mantieni il file esistente
+ErrorReadingExistingDest=Si è verificato un errore durante la lettura del file esistente:
+FileExistsSelectAction=Seleziona azione
+FileExists2=Il file esiste già.
+FileExistsOverwriteExisting=S&ovrascrivi il file esistente
+FileExistsKeepExisting=&Mantieni il file esistente
+FileExistsOverwriteOrKeepAll=&Applica questa azione per i prossimi conflitti
+ExistingFileNewerSelectAction=Seleziona azione
+ExistingFileNewer2=Il file esistente è più recente del file che si sta cercando di installare.
+ExistingFileNewerOverwriteExisting=S&ovrascrivi il file esistente
+ExistingFileNewerKeepExisting=&Mantieni il file esistente (suggerito)
+ExistingFileNewerOverwriteOrKeepAll=&Applica questa azione per i prossimi conflitti
+ErrorChangingAttr=Si è verificato un errore durante il tentativo di modifica dell'attributo del file esistente:
+ErrorCreatingTemp=Si è verificato un errore durante la creazione di un file nella cartella di installazione:
+ErrorReadingSource=Si è verificato un errore durante la lettura del file sorgente:
+ErrorCopying=Si è verificato un errore durante la copia di un file:
+ErrorReplacingExistingFile=Si è verificato un errore durante la sovrascrittura del file esistente:
+ErrorRestartReplace=Errore durante riavvio o sostituzione:
+ErrorRenamingTemp=Si è verificato un errore durante il tentativo di rinominare un file nella cartella di installazione:
+ErrorRegisterServer=Impossibile registrare la DLL/OCX: %1
+ErrorRegSvr32Failed=RegSvr32 è fallito con codice di uscita %1
+ErrorRegisterTypeLib=Impossibile registrare la libreria di tipo: %1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32bit
+UninstallDisplayNameMark64Bit=64bit
+UninstallDisplayNameMarkAllUsers=Tutti gli utenti
+UninstallDisplayNameMarkCurrentUser=Utente attuale
+
+; *** Post-installation errors
+ErrorOpeningReadme=Si è verificato un errore durante l'apertura del file LEGGIMI.
+ErrorRestartingComputer=Impossibile riavviare il sistema. Riavvia il sistema manualmente.
+
+; *** Uninstaller messages
+UninstallNotFound=Il file "%1" non esiste.%n%nImpossibile disinstallare.
+UninstallOpenError=Il file "%1" non può essere aperto.%n%nImpossibile disinstallare
+UninstallUnsupportedVer=Il file registro di disinstallazione "%1" è in un formato non riconosciuto da questa versione del programma di disinstallazione.%n%nImpossibile disinstallare
+UninstallUnknownEntry=Trovata una voce sconosciuta (%1) nel file registro di disinstallazione
+ConfirmUninstall=Vuoi rimuovere completamente %1 e tutti i suoi componenti?
+UninstallOnlyOnWin64=Questa applicazione può essere disinstallata solo in Windows a 64-bit.
+OnlyAdminCanUninstall=Questa applicazione può essere disinstallata solo da un utente con privilegi di amministratore.
+UninstallStatusLabel=Attendi fino a che %1 è stato rimosso dal computer.
+UninstalledAll=Disinstallazione di %1 completata.
+UninstalledMost=Disinstallazione di %1 completata.%n%nAlcuni elementi non possono essere rimossi.%n%nDovranno essere rimossi manualmente.
+UninstalledAndNeedsRestart=Per completare la disinstallazione di %1, è necessario riavviare il sistema.%n%nVuoi riavviare il sistema adesso?
+UninstallDataCorrupted=Il file "%1" è danneggiato. Impossibile disinstallare
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=Vuoi rimuovere il file condiviso?
+ConfirmDeleteSharedFile2=Il sistema indica che il seguente file condiviso non è più usato da nessun programma.%nVuoi rimuovere questo file condiviso?%nSe qualche programma usasse questo file, potrebbe non funzionare più correttamente.%nSe non sei sicuro, seleziona "No".%nLasciare il file nel sistema non può causare danni.
+SharedFileNameLabel=Nome del file:
+SharedFileLocationLabel=Percorso:
+WizardUninstalling=Stato disinstallazione
+StatusUninstalling=Disinstallazione di %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=Installazione di %1.
+ShutdownBlockReasonUninstallingApp=Disinstallazione di %1.
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 versione %2
+AdditionalIcons=Icone aggiuntive:
+CreateDesktopIcon=Crea un'icona sul &desktop
+CreateQuickLaunchIcon=Crea un'icona nella &barra 'Avvio veloce'
+ProgramOnTheWeb=Sito web di %1
+UninstallProgram=Disinstalla %1
+LaunchProgram=Avvia %1
+AssocFileExtension=&Associa i file con estensione %2 a %1
+AssocingFileExtension=Associazione dei file con estensione %2 a %1...
+AutoStartProgramGroupDescription=Esecuzione automatica:
+AutoStartProgram=Esegui automaticamente %1
+AddonHostProgramNotFound=Impossibile individuare %1 nella cartella selezionata.%n%nVuoi continuare ugualmente?

--- a/deploy/languages/Korean.isl
+++ b/deploy/languages/Korean.isl
@@ -1,0 +1,390 @@
+﻿; *** Inno Setup version 6.1.0+ Korean messages ***
+
+; ▒ 6.2.2+ Translator: VenusGirl (venusgirl@outlook.com)
+; ▒ 6.2.0+ Translator: Logan.Hwang (logan.hwang@blueant.kr)
+; ▒ 6.0.3+ Translator: SungDong Kim (acroedit@gmail.com)
+; ▒ 5.5.3+ Translator: Domddol (domddol@gmail.com)
+; ▒ Contributors: Hansoo KIM (iryna7@gmail.com), Woong-Jae An (a183393@hanmail.net)
+; ▒ 이 번역은 한국어 맞춤법을 준수합니다.
+;
+; 이 파일의 사용자 제공 번역을 다운로드하려면 다음으로 이동하십시오:
+;   https://jrsoftware.org/files/istrans/
+
+; 참고: 이 텍스트를 번역할 때는 InnoSetup 메시지에
+; 마침표가 자동으로 추가되므로 아직 없는 메시지의 끝에
+; 마침표(.)를 추가하지 마십시오 (마침표를 추가하면
+; 두 개의 마침표가 표시됩니다).
+
+[LangOptions]
+; 다음 세 항목은 매우 중요합니다. 도움말 파일의
+; '[LangOptions] 섹션' 항목을 읽고 이해하십시오.
+LanguageName=한국어
+LanguageID=$0412
+LanguageCodePage=949
+; 번역할 언어가 특수 글꼴 또는 크기를 필요로 하는 경우
+; 다음 항목 중 하나를 주석 해제하고 적절하게 변경하십시오.
+;DialogFontName=
+;DialogFontSize=8
+;WelcomeFontName=Verdana
+;WelcomeFontSize=12
+;TitleFontName=Arial
+;TitleFontSize=29
+;CopyrightFontName=Arial
+;CopyrightFontSize=8
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=설치
+SetupWindowTitle=%1 설치
+UninstallAppTitle=제거
+UninstallAppFullTitle=%1 제거
+
+; *** Misc. common
+InformationTitle=정보
+ConfirmTitle=확인
+ErrorTitle=오류
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=%1을(를) 설치합니다, 계속하시겠습니까?
+LdrCannotCreateTemp=임시 파일을 만들 수 없습니다. 설치가 중단되었습니다.
+LdrCannotExecTemp=임시 디렉터리에서 파일을 실행할 수 없습니다. 설치가 중단되었습니다.
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1.%n%n오류 %2: %3
+SetupFileMissing=%1 파일이 설치 디렉터리에 없습니다. 문제를 해결하거나 프로그램의 새 사본을 구하십시오.
+SetupFileCorrupt=설치 파일이 손상되었습니다. 프로그램의 새 사본을 구하십시오.
+SetupFileCorruptOrWrongVer=설치 파일이 손상되었거나 이 버전의 설치 프로그램과 호환되지 않습니다. 문제를 해결하거나 프로그램의 새 복사본을 구하십시오.
+InvalidParameter=명령줄에 잘못된 매개변수가 전달되었습니다:%n%n%1
+SetupAlreadyRunning=설치가 이미 실행 중입니다.
+WindowsVersionNotSupported=이 프로그램은 컴퓨터에서 실행 중인 Windows 버전을 지원하지 않습니다.
+WindowsServicePackRequired=이 프로그램을 사용하려면 %1 서비스 팩 %2 이상이 필요합니다.
+NotOnThisPlatform=이 프로그램은 %1에서 실행되지 않습니다.
+OnlyOnThisPlatform=이 프로그램은 %1에서 실행되어야 합니다.
+OnlyOnTheseArchitectures=이 프로그램은 다음 프로세서 아키텍처용으로 설계된 Windows 버전에만 설치할 수 있습니다:%n%n%1
+WinVersionTooLowError=이 프로그램에는 %1 버전 %2 이상이 필요합니다.
+WinVersionTooHighError=%1 버전 %2 이상에 이 프로그램을 설치할 수 없습니다.
+AdminPrivilegesRequired=이 프로그램을 설치할 때 관리자로 로그인해야 합니다.
+PowerUserPrivilegesRequired=이 프로그램을 설치할 때 관리자 또는 Power Users 그룹의 구성원으로 로그인해야 합니다.
+SetupAppRunningError=설치에서 %1이(가) 현재 실행 중임을 감지했습니다.%n%n지금 모든 인스턴스를 닫은 다음 확인을 클릭하여 계속하거나 취소를 클릭하여 종료하십시오.
+UninstallAppRunningError=제거에서 %1이(가) 현재 실행 중임을 감지했습니다.%n%n지금 모든 인스턴스를 닫은 다음 확인을 클릭하여 계속하거나 취소를 클릭하여 종료하십시오.
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=설치 모드 선택
+PrivilegesRequiredOverrideInstruction=설치 모드를 선택해 주십시오
+PrivilegesRequiredOverrideText1=%1은 모든 사용자 (관리자 권한 필요) 또는 사용자용으로 설치합니다.
+PrivilegesRequiredOverrideText2=%1은 현재 사용자 또는 모든 사용자 (관리자 권한 필요)용으로 설치합니다.
+PrivilegesRequiredOverrideAllUsers=모든 사용자용으로 설치(&A)
+PrivilegesRequiredOverrideAllUsersRecommended=모든 사용자용으로 설치 (추천)(&A)
+PrivilegesRequiredOverrideCurrentUser=현재 사용자용으로 설치(&M)
+PrivilegesRequiredOverrideCurrentUserRecommended=현재 사용자용으로 설치 (추천)(&M)
+
+; *** Misc. errors
+ErrorCreatingDir=설치 프로그램에서 "%1" 디렉터리를 만들지 못했습니다.
+ErrorTooManyFilesInDir="%1" 디렉터리에 파일이 너무 많아서 파일을 만들 수 없습니다
+
+; *** Setup common messages
+ExitSetupTitle=설치 종료
+ExitSetupMessage=설치가 완료되지 않았습니다. 지금 종료하면 프로그램이 설치되지 않습니다.%n%n설치를 다시 실행하여 설치를 완료할 수 있습니다.%n%n설치를 종료하시겠습니까?
+AboutSetupMenuItem=설치 정보(&A)...
+AboutSetupTitle=설치 정보
+AboutSetupMessage=%1 버전 %2%n%3%n%n%1 홈 페이지:%n%4
+AboutSetupNote=
+TranslatorNote=
+
+; *** Buttons
+ButtonBack=< 뒤로(&B)
+ButtonNext=다음(&N) >
+ButtonInstall=설치(&I)
+ButtonOK=확인
+ButtonCancel=취소
+ButtonYes=예(&Y)
+ButtonYesToAll=모두 예(&A)
+ButtonNo=아니오(&N)
+ButtonNoToAll=모두 아니오(&O)
+ButtonFinish=종료(&F)
+ButtonBrowse=찾아보기(&B)...
+ButtonWizardBrowse=찾아보기(&R)...
+ButtonNewFolder=새 폴더 만들기(&M)
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=설치 언어 선택
+SelectLanguageLabel=설치 중에 사용할 언어를 선택하십시오.
+
+; *** Common wizard text
+ClickNext=다음을 클릭하여 계속하거나 취소를 클릭하여 설치를 종료합니다.
+BeveledLabel=
+BrowseDialogTitle=폴더 찾아보기
+BrowseDialogLabel=아래 목록에서 폴더를 선택한 후 확인을 클릭하십시오.
+NewFolderName=새 폴더
+
+; *** "Welcome" wizard page
+WelcomeLabel1=[name] 설치 마법사에 오신 것을 환영합니다
+WelcomeLabel2=컴퓨터에 [name/ver]가 설치됩니다.%n%n계속하기 전에 다른 모든 응용 프로그램을 닫는 것이 좋습니다.
+
+; *** "Password" wizard page
+WizardPassword=암호
+PasswordLabel1=이 설치는 암호로 보호됩니다.
+PasswordLabel3=암호를 입력한 후 다음을 클릭하여 계속하십시오. 암호는 대소문자를 구분합니다.
+PasswordEditLabel=암호(&P):
+IncorrectPassword=입력한 암호가 올바르지 않습니다. 다시 시도하십시오.
+
+; *** "License Agreement" wizard page
+WizardLicense=사용권 계약
+LicenseLabel=계속하기 전에 다음 중요한 정보를 읽어보십시오.
+LicenseLabel3=다음 사용권 계약을 읽어보십시오. 설치를 계속하기 전에 이 계약 조건에 동의해야 합니다.
+LicenseAccepted=동의합니다(&A)
+LicenseNotAccepted=동의하지 않습니다(&D)
+
+; *** "Information" wizard pages
+WizardInfoBefore=정보
+InfoBeforeLabel=계속하기 전에 다음 중요한 정보를 읽어보십시오.
+InfoBeforeClickLabel=설치를 계속할 준비가 되었으면 다음을 클릭합니다.
+WizardInfoAfter=정보
+InfoAfterLabel=계속하기 전에 다음 중요한 정보를 읽어보십시오.
+InfoAfterClickLabel=설치를 계속할 준비가 되었으면 다음을 클릭합니다.
+
+; *** "User Information" wizard page
+WizardUserInfo=사용자 정보
+UserInfoDesc=사용자 정보를 입력하십시오.
+UserInfoName=사용자 이름(&U):
+UserInfoOrg=조직(&O):
+UserInfoSerial=일련 번호:(&S):
+UserInfoNameRequired=이름을 입력해야 합니다.
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=대상 위치 선택
+SelectDirDesc=[name]을(를) 어디에 설치하시겠습니까?
+SelectDirLabel3=다음 폴더에 [name]을(를) 설치합니다.
+SelectDirBrowseLabel=계속하려면 다음을 클릭합니다. 다른 폴더를 선택하려면 찾아보기를 클릭합니다.
+DiskSpaceGBLabel=이 프로그램은 최소 [gb] GB의 디스크 여유 공간이 필요합니다.
+DiskSpaceMBLabel=이 프로그램은 최소 [mb] MB의 디스크 여유 공간이 필요합니다.
+CannotInstallToNetworkDrive=네트워크 드라이브에 설치할 수 없습니다.
+CannotInstallToUNCPath=UNC 경로에 설치할 수 없습니다.
+InvalidPath=드라이브 문자를 포함한 전체 경로를 입력해야 합니다. 예:%n%nC:\APP%n%n 또는 UNC 경로 형식:%n%n\\server\share
+InvalidDrive=선택한 드라이브 또는 UNC 공유가 존재하지 않거나 액세스할 수 없습니다, 다른 경로를 선택하십시오.
+DiskSpaceWarningTitle=디스크 공간이 부족합니다
+DiskSpaceWarning=설치 시 최소 %1 KB 디스크 공간이 필요하지만, 선택한 드라이브의 여유 공간은 %2 KB 밖에 없습니다.%n%n그래도 계속하시겠습니까?
+DirNameTooLong=폴더 이름 또는 경로가 너무 깁니다.
+InvalidDirName=폴더 이름이 유효하지 않습니다.
+BadDirName32=폴더 이름은 다음 문자를 포함할 수 없습니다:%n%n%1
+DirExistsTitle=폴더가 존재합니다
+DirExists=폴더 %n%n%1%n%n이(가) 이미 존재합니다, 그래도 해당 폴더에 설치하시겠습니까?
+DirDoesntExistTitle=폴더가 존재하지 않습니다
+DirDoesntExist=폴더 %n%n%1%n%n이(가) 존재하지 않습니다, 폴더를 만드시겠습니까?
+
+; *** "Select Components" wizard page
+WizardSelectComponents=구성 요소 선택
+SelectComponentsDesc=어떤 구성 요소를 설치해야 합니까?
+SelectComponentsLabel2=설치할 구성 요소를 선택하고 설치하지 않을 구성 요소를 지웁니다. 계속할 준비가 되면 다음을 클릭합니다.
+FullInstallation=모두 설치
+; 가능하면 'Compact'를 'Minimal'로 번역하지 마십시오 (귀하의 언어로 '최소'를 의미합니다).
+CompactInstallation=최소 설치
+CustomInstallation=사용자 지정 설치
+NoUninstallWarningTitle=구성 요소가 존재합니다
+NoUninstallWarning=다음 구성 요소가 컴퓨터에 이미 설치되어 있습니다: %n%n%1%n%n이러한 구성 요소를 선택해도 제거되지 않습니다.%n%n계속하시겠습니까?
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=현재 선택은 최소 [gb] GB의 디스크 여유 공간이 필요합니다.
+ComponentsDiskSpaceMBLabel=현재 선택은 최소 [mb] MB의 디스크 여유 공간이 필요합니다.
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=추가 작업 선택
+SelectTasksDesc=어떤 추가 작업을 수행해야 합니까?
+SelectTasksLabel2=[name]을(를) 설치하는 동안 수행할 추가 작업을 선택하고 다음을 클릭합니다.
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=시작 메뉴 폴더 선택
+SelectStartMenuFolderDesc=프로그램의 바로가기를 어디에 설치하시겠습니까?
+SelectStartMenuFolderLabel3=설치는 다음 시작 메뉴 폴더에 프로그램 바로가기를 만듭니다.
+SelectStartMenuFolderBrowseLabel=계속하려면 다음을 클릭합니다. 다른 폴더를 선택하려면 찾아보기를 클릭합니다.
+MustEnterGroupName=폴더 이름을 입력하십시오.
+GroupNameTooLong=폴더 이름 또는 경로가 너무 깁니다.
+InvalidGroupName=폴더 이름이 유효하지 않습니다.
+BadGroupName=폴더 이름은 다음 문자를 포함할 수 없습니다:%n%n%1
+NoProgramGroupCheck2=시작 메뉴 폴더를 만들지 않음(&D)
+
+; *** "Ready to Install" wizard page
+WizardReady=설치 준비 완료
+ReadyLabel1=[name]을(를) 컴퓨터에 설치할 준비가 되었습니다.
+ReadyLabel2a=설치를 클릭하여 설치를 계속하거나 설정을 검토하거나 변경하려면 뒤로를 클릭합니다.
+ReadyLabel2b=설치를 클릭하여 설치를 계속합니다.
+ReadyMemoUserInfo=사용자 정보:
+ReadyMemoDir=대상 위치:
+ReadyMemoType=설치 유형:
+ReadyMemoComponents=선택한 구성 요소:
+ReadyMemoGroup=시작 메뉴 폴더:
+ReadyMemoTasks=추가 작업:
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel=추가 파일 다운로드 중...
+ButtonStopDownload=다운로드 중지(&S)
+StopDownload=다운로드를 중지하시겠습니까?
+ErrorDownloadAborted=다운로드가 중지되었습니다
+ErrorDownloadFailed=다운로드에 실패했습니다: %1 %2
+ErrorDownloadSizeFailed=크기를 가져오지 못했습니다: %1 %2
+ErrorFileHash1=파일 해시에 실패했습니다: %1
+ErrorFileHash2=잘못된 파일 해시: 예상 %1, 찾음 %2
+ErrorProgress=잘못된 진행 상황: %1 / %2
+ErrorFileSize=잘못된 파일 크기: 예상 %1, 찾음 %2
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=설치 준비 중
+PreparingDesc=컴퓨터에 [name] 설치를 준비하는 중입니다.
+PreviousInstallNotCompleted=이전 프로그램의 설치/제거가 완료되지 않았습니다. 설치를 완료하려면 컴퓨터를 다시 시작해야 합니다.%n%n컴퓨터를 재시작한 후 설치를 다시 실행하여 [name] 설치를 완료하십시오.
+CannotContinue=설치를 계속할 수 없습니다. 종료하려면 취소를 클릭하십시오.
+ApplicationsFound=다음 응용 프로그램에서 설치 프로그램에서 업데이트해야 하는 파일을 사용하고 있습니다. 이러한 응용 프로그램을 자동으로 닫도록 허용하는 것이 좋습니다.
+ApplicationsFound2=다음 응용 프로그램에서 설치 프로그램에서 업데이트해야 하는 파일을 사용하고 있습니다. 이러한 응용 프로그램을 자동으로 닫도록 허용하는 것이 좋습니다. 설치가 완료되면 응용 프로그램을 다시 시작하려고 시도합니다.
+CloseApplications=응용 프로그램 자동 닫기(&A)
+DontCloseApplications=응용 프로그램을 닫지 않음(&D)
+ErrorCloseApplications=모든 응용 프로그램을 자동으로 닫지 못했습니다. 계속하기 전에 설치 프로그램에서 업데이트해야 하는 파일을 사용하여 모든 응용 프로그램을 닫는 것이 좋습니다.
+PrepareToInstallNeedsRestart=컴퓨터를 다시 시작해야 합니다. 컴퓨터를 다시 시작한 후 설치를 다시 실행하여 [name] 설치를 완료하십시오.%n%n지금 다시 시작하시겠습니까?
+
+; *** "Installing" wizard page
+WizardInstalling=설치 중
+InstallingLabel=컴퓨터에 [name]을(를) 설치하는 동안 잠시 기다려 주십시오.
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=[name] 설치 마법사 완료
+FinishedLabelNoIcons=컴퓨터에 [name] 설치를 완료했습니다.
+FinishedLabel=컴퓨터에 [name] 설치를 완료했습니다. 설치된 바로가기를 선택하여 응용 프로그램을 시작할 수 있습니다.
+ClickFinish=설치를 종료하려면 마침을 클릭하십시오.
+FinishedRestartLabel=[name] 설치를 완료하려면 컴퓨터를 다시 시작해야 합니다. 지금 다시 시작하시겠습니까?
+FinishedRestartMessage=[name] 설치를 완료하려면 컴퓨터를 다시 시작해야 합니다.%n%n지금 다시 시작하시겠습니까?
+ShowReadmeCheck=예, README 파일을 보고 싶습니다.
+YesRadio=예, 지금 컴퓨터를 다시 시작합니다(&Y)
+NoRadio=아니오, 나중에 컴퓨터를 다시 시작하겠습니다(&N)
+; 예를 들어 'Run MyProg.exe'로 사용됩니다'
+RunEntryExec=%1 실행
+; 예를 들어 'Readme.txt 보기'로 사용됩니다'
+RunEntryShellExec=%1 보기
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=설치에 다음 디스크가 필요합니다
+SelectDiskLabel2=디스크 %1을(를) 삽입하고 확인을 클릭하십시오.%n%n이 디스크의 파일을 아래에 표시된 폴더 이외의 폴더에서 찾을 수 있으면 올바른 경로를 입력하거나 찾아보기를 클릭하십시오.
+PathLabel=경로(&P):
+FileNotInDir2="%1" 파일을 "%2"에서 찾을 수 없습니다. 올바른 디스크를 넣거나 다른 폴더를 선택하십시오.
+SelectDirectoryLabel=다음 디스크의 위치를 지정하십시오.
+
+; *** Installation phase messages
+SetupAborted=설치가 완료되지 않았습니다.%n%n문제를 해결한 후 설치를 다시 실행하십시오.
+AbortRetryIgnoreSelectAction=작업 선택
+AbortRetryIgnoreRetry=재시도(&T)
+AbortRetryIgnoreIgnore=오류를 무시하고 진행(&I)
+AbortRetryIgnoreCancel=설치 취소
+
+; *** Installation status messages
+StatusClosingApplications=응용 프로그램을 닫는 중...
+StatusCreateDirs=디렉터리를 만드는 중...
+StatusExtractFiles=파일을 추출하는 중...
+StatusCreateIcons=바로가기를 만드는 중...
+StatusCreateIniEntries=INI 항목을 만드는 중...
+StatusCreateRegistryEntries=레지스트리 항목을 만드는 중...
+StatusRegisterFiles=파일을 등록하는 중...
+StatusSavingUninstall=제거 정보를 저장하는 중...
+StatusRunProgram=설치를 완료하는 중...
+StatusRestartingApplications=응용 프로그램을 다시 시작하는 중...
+StatusRollback=변경 내용을 롤백하는 중...
+
+; *** Misc. errors
+ErrorInternal2=내부 오류: %1
+ErrorFunctionFailedNoCode=%1 실패
+ErrorFunctionFailed=%1 실패; 코드 %2
+ErrorFunctionFailedWithMessage=%1 실패, 코드: %2.%n%3
+ErrorExecutingProgram=파일 실행 오류:%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=레지스트리 키 열기 오류:%n%1\%2
+ErrorRegCreateKey=레지스트리 키 생성 오류:%n%1\%2
+ErrorRegWriteKey=레지스트리 키 쓰기 오류:%n%1\%2
+
+; *** INI errors
+ErrorIniEntry="%1" 파일에 INI 항목 만들기 오류입니다.
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=이 파일 건너뛰기 (추천하지 않음)(&S)
+FileAbortRetryIgnoreIgnoreNotRecommended=오류를 무시하고 계속 (추천하지 않음)(&I)
+SourceIsCorrupted=원본 파일이 손상되었습니다
+SourceDoesntExist=원본 파일 "%1"이(가) 없습니다
+ExistingFileReadOnly2=읽기 전용으로 표시되어 있으므로 기존 파일을 교체할 수 없습니다.
+ExistingFileReadOnlyRetry=읽기 전용 속성을 제거하고 다시 시도(&R)
+ExistingFileReadOnlyKeepExisting=기존 파일 유지(&K)
+ErrorReadingExistingDest=기존 파일을 읽는 동안 오류 발생:
+FileExistsSelectAction=작업 선택
+FileExists2=파일이 이미 존재합니다.
+FileExistsOverwriteExisting=기존 파일 덮어쓰기(&O)
+FileExistsKeepExisting=기존 파일 유지(&K)
+FileExistsOverwriteOrKeepAll=다음 충돌에 대해 이 작업 수행(&D)
+ExistingFileNewerSelectAction=작업 선택
+ExistingFileNewer2=설치 프로그램에서 설치하려는 파일보다 기존 파일이 더 최신입니다.
+ExistingFileNewerOverwriteExisting=기존 파일 덮어쓰기(&O)
+ExistingFileNewerKeepExisting=기존 파일 유지 (추천)(&K)
+ExistingFileNewerOverwriteOrKeepAll=다음 충돌에 대해 이 작업 수행(&D)
+ErrorChangingAttr=기존 파일의 속성을 변경하는 동안 오류 발생:
+ErrorCreatingTemp=대상 디렉터리에 파일을 만드는 동안 오류 발생:
+ErrorReadingSource=원본 파일을 읽는 동안 오류 발생:
+ErrorCopying=파일을 복사하는 동안 오류 발생:
+ErrorReplacingExistingFile=기존 파일을 교체하는 동안 오류 발생:
+ErrorRestartReplace=RestartReplace 실패:
+ErrorRenamingTemp=대상 디렉터리 내의 파일 이름을 바꾸는 동안 오류 발생:
+ErrorRegisterServer=DLL/OCX를 등록할 수 없습니다: %1
+ErrorRegSvr32Failed=종료 코드 %1로 인해 RegSvr32가 실패했습니다
+ErrorRegisterTypeLib=유형 라이브러리를 등록할 수 없습니다: %1
+
+; *** Uninstall display name markings
+; 예를 들어 '내 프로그램'으로 사용됩니다 (32비트)'
+UninstallDisplayNameMark=%1 (%2)비트
+; 예를 들어 '내 프로그램'으로 사용됩니다 (32비트, 모든 사용자)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32비트
+UninstallDisplayNameMark64Bit=64비트
+UninstallDisplayNameMarkAllUsers=모든 사용자
+UninstallDisplayNameMarkCurrentUser=현재 사용자
+
+; *** Post-installation errors
+ErrorOpeningReadme=README 파일을 여는 동안 오류가 발생했습니다.
+ErrorRestartingComputer=컴퓨터를 다시 시작하지 못했습니다. 이 작업을 수동으로 수행하십시오.
+
+; *** Uninstaller messages
+UninstallNotFound="%1" 파일이 없습니다. 제거할 수 없습니다.
+UninstallOpenError="%1" 파일을 열 수 없습니다. 제거할 수 없습니다
+UninstallUnsupportedVer="%1" 제거 로그 파일이 현재 버전의 제거 프로그램에서 인식할 수 없는 형식입니다. 제거할 수 없습니다
+UninstallUnknownEntry=제거 로그에 알 수 없는 항목 (%1)이 있습니다
+ConfirmUninstall=%1 및 해당 구성 요소를 모두 제거하시겠습니까?
+UninstallOnlyOnWin64=이 설치는 64비트 Windows에서만 제거할 수 있습니다.
+OnlyAdminCanUninstall=이 설치는 관리자 권한이 있는 사용자만 제거할 수 있습니다.
+UninstallStatusLabel=%1이(가) 컴퓨터에서 제거되는 동안 기다려 주십시오.
+UninstalledAll=%1이(가) 컴퓨터에서 성공적으로 제거되었습니다.
+UninstalledMost=%1 제거가 완료되었습니다.%n%n일부 요소를 제거할 수 없습니다. 수동으로 제거할 수 있습니다.
+UninstalledAndNeedsRestart=%1 제거를 완료하려면 컴퓨터를 다시 시작해야 합니다.%n%n지금 다시 시작하시겠습니까?
+UninstallDataCorrupted="%1" 파일이 손상되었습니다. 제거할 수 없습니다.
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=공유 파일을 제거하시겠습니까?
+ConfirmDeleteSharedFile2=시스템에 다음 공유 파일이 더 이상 어떤 프로그램에서도 사용되지 않는 것으로 표시됩니다. 제거에서 이 공유 파일을 제거하시겠습니까?%n%n이 파일을 계속 사용하고 있고 파일이 제거된 프로그램이 있으면 해당 프로그램이 제대로 작동하지 않을 수 있습니다. 확실하지 않은 경우 아니요를 선택합니다. 파일을 시스템에 남겨두어도 아무런 해가 되지 않습니다.
+SharedFileNameLabel=파일 이름:
+SharedFileLocationLabel=위치:
+WizardUninstalling=제거 상태
+StatusUninstalling=%1을(를) 제거하는 중...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=%1을(를) 설치하는 중입니다.
+ShutdownBlockReasonUninstallingApp=%1을(를) 제거하는 중입니다.
+
+; 아래 사용자 지정 메시지는 설치 프로그램 자체에서 사용하지 않지만
+; 스크립트에서 사용할 경우 해당 메시지를 번역할 수 있습니다.
+
+[CustomMessages]
+
+NameAndVersion=%1 버전 %2
+AdditionalIcons=바로가기 추가:
+CreateDesktopIcon=바탕화면에 바로가기 만들기(&D)
+CreateQuickLaunchIcon=빠른 실행 아이콘 만들기(&Q)
+ProgramOnTheWeb=%1 웹페이지
+UninstallProgram=LaunchProgram=%1 실행
+AssocFileExtension=%1을 %2 파일 확장자에 연결
+AssocingFileExtension=%1을 %2 파일 확장자와 연결하는 중...
+AutoStartProgramGroupDescription=시작:
+AutoStartProgram=%1 자동 시작
+AddonHostProgramNotFound=%1을(를) 선택한 폴더에서 찾을 수 없습니다.%n%n계속하시겠습니까?

--- a/deploy/languages/Portuguese.isl
+++ b/deploy/languages/Portuguese.isl
@@ -1,0 +1,366 @@
+; *** Inno Setup version 6.1.0+ Portuguese (Portugal) messages ***
+;
+; Maintained by Nuno Silva (nars AT gmx.net)
+
+[LangOptions]
+LanguageName=Portugu<00EA>s (Portugal)
+LanguageID=$0816
+LanguageCodePage=1252
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=Instalação
+SetupWindowTitle=%1 - Instalação
+UninstallAppTitle=Desinstalação
+UninstallAppFullTitle=%1 - Desinstalação
+
+; *** Misc. common
+InformationTitle=Informação
+ConfirmTitle=Confirmação
+ErrorTitle=Erro
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=Irá ser instalado o %1. Deseja continuar?
+LdrCannotCreateTemp=Não foi possível criar um ficheiro temporário. Instalação cancelada
+LdrCannotExecTemp=Não foi possível executar um ficheiro na directoria temporária. Instalação cancelada
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1.%n%nErro %2: %3
+SetupFileMissing=O ficheiro %1 não foi encontrado na pasta de instalação. Corrija o problema ou obtenha uma nova cópia do programa.
+SetupFileCorrupt=Os ficheiros de instalação estão corrompidos. Obtenha uma nova cópia do programa.
+SetupFileCorruptOrWrongVer=Os ficheiros de instalação estão corrompidos, ou são incompatíveis com esta versão do Assistente de Instalação. Corrija o problema ou obtenha uma nova cópia do programa.
+InvalidParameter=Foi especificado um parâmetro inválido na linha de comando:%n%n%1
+SetupAlreadyRunning=A instalação já está em execução.
+WindowsVersionNotSupported=Este programa não suporta a versão do Windows que está a utilizar.
+WindowsServicePackRequired=Este programa necessita de %1 Service Pack %2 ou mais recente.
+NotOnThisPlatform=Este programa não pode ser executado no %1.
+OnlyOnThisPlatform=Este programa deve ser executado no %1.
+OnlyOnTheseArchitectures=Este programa só pode ser instalado em versões do Windows preparadas para as seguintes arquitecturas:%n%n%1
+WinVersionTooLowError=Este programa necessita do %1 versão %2 ou mais recente.
+WinVersionTooHighError=Este programa não pode ser instalado no %1 versão %2 ou mais recente.
+AdminPrivilegesRequired=Deve iniciar sessão como administrador para instalar este programa.
+PowerUserPrivilegesRequired=Deve iniciar sessão como administrador ou membro do grupo de Super Utilizadores para instalar este programa.
+SetupAppRunningError=O Assistente de Instalação detectou que o %1 está em execução. Feche-o e de seguida clique em OK para continuar, ou clique em Cancelar para cancelar a instalação.
+UninstallAppRunningError=O Assistente de Desinstalação detectou que o %1 está em execução. Feche-o e de seguida clique em OK para continuar, ou clique em Cancelar para cancelar a desinstalação.
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=Seleccione o Modo de Instalação
+PrivilegesRequiredOverrideInstruction=Seleccione o Modo de Instalação
+PrivilegesRequiredOverrideText1=%1 pode ser instalado para todos os utilizadores (necessita de privilégios administrativos), ou só para si.
+PrivilegesRequiredOverrideText2=%1 pode ser instalado só para si, ou para todos os utilizadores (necessita de privilégios administrativos).
+PrivilegesRequiredOverrideAllUsers=Instalar para &todos os utilizadores
+PrivilegesRequiredOverrideAllUsersRecommended=Instalar para &todos os utilizadores (recomendado)
+PrivilegesRequiredOverrideCurrentUser=Instalar apenas para &mim
+PrivilegesRequiredOverrideCurrentUserRecommended=Instalar apenas para &mim (recomendado)
+
+; *** Misc. errors
+ErrorCreatingDir=O Assistente de Instalação não consegue criar a directoria "%1"
+ErrorTooManyFilesInDir=Não é possível criar um ficheiro na directoria "%1" porque esta contém demasiados ficheiros
+
+; *** Setup common messages
+ExitSetupTitle=Terminar a instalação
+ExitSetupMessage=A instalação não está completa. Se terminar agora, o programa não será instalado.%n%nMais tarde poderá executar novamente este Assistente de Instalação e concluir a instalação.%n%nDeseja terminar a instalação?
+AboutSetupMenuItem=&Acerca de...
+AboutSetupTitle=Acerca do Assistente de Instalação
+AboutSetupMessage=%1 versão %2%n%3%n%n%1 home page:%n%4
+AboutSetupNote=
+TranslatorNote=Portuguese translation maintained by NARS (nars@gmx.net)
+
+; *** Buttons
+ButtonBack=< &Anterior
+ButtonNext=&Seguinte >
+ButtonInstall=&Instalar
+ButtonOK=OK
+ButtonCancel=Cancelar
+ButtonYes=&Sim
+ButtonYesToAll=Sim para &todos
+ButtonNo=&Não
+ButtonNoToAll=Nã&o para todos
+ButtonFinish=&Concluir
+ButtonBrowse=&Procurar...
+ButtonWizardBrowse=P&rocurar...
+ButtonNewFolder=&Criar Nova Pasta
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=Seleccione o Idioma do Assistente de Instalação
+SelectLanguageLabel=Seleccione o idioma para usar durante a Instalação.
+
+; *** Common wizard text
+ClickNext=Clique em Seguinte para continuar ou em Cancelar para cancelar a instalação.
+BeveledLabel=
+BrowseDialogTitle=Procurar Pasta
+BrowseDialogLabel=Seleccione uma pasta na lista abaixo e clique em OK.
+NewFolderName=Nova Pasta
+
+; *** "Welcome" wizard page
+WelcomeLabel1=Bem-vindo ao Assistente de Instalação do [name]
+WelcomeLabel2=O Assistente de Instalação irá instalar o [name/ver] no seu computador.%n%nÉ recomendado que feche todas as outras aplicações antes de continuar.
+
+; *** "Password" wizard page
+WizardPassword=Palavra-passe
+PasswordLabel1=Esta instalação está protegida por palavra-passe.
+PasswordLabel3=Insira a palavra-passe e de seguida clique em Seguinte para continuar. Na palavra-passe existe diferença entre maiúsculas e minúsculas.
+PasswordEditLabel=&Palavra-passe:
+IncorrectPassword=A palavra-passe que introduziu não está correcta. Tente novamente.
+
+; *** "License Agreement" wizard page
+WizardLicense=Contrato de licença
+LicenseLabel=É importante que leia as seguintes informações antes de continuar.
+LicenseLabel3=Leia atentamente o seguinte contrato de licença. Deve aceitar os termos do contrato antes de continuar a instalação.
+LicenseAccepted=A&ceito o contrato
+LicenseNotAccepted=&Não aceito o contrato
+
+; *** "Information" wizard pages
+WizardInfoBefore=Informação
+InfoBeforeLabel=É importante que leia as seguintes informações antes de continuar.
+InfoBeforeClickLabel=Quando estiver pronto para continuar clique em Seguinte.
+WizardInfoAfter=Informação
+InfoAfterLabel=É importante que leia as seguintes informações antes de continuar.
+InfoAfterClickLabel=Quando estiver pronto para continuar clique em Seguinte.
+
+; *** "User Information" wizard page
+WizardUserInfo=Informações do utilizador
+UserInfoDesc=Introduza as suas informações.
+UserInfoName=Nome do &utilizador:
+UserInfoOrg=&Organização:
+UserInfoSerial=&Número de série:
+UserInfoNameRequired=Deve introduzir um nome.
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=Seleccione a localização de destino
+SelectDirDesc=Onde deverá ser instalado o [name]?
+SelectDirLabel3=O [name] será instalado na seguinte pasta.
+SelectDirBrowseLabel=Para continuar, clique em Seguinte. Se desejar seleccionar uma pasta diferente, clique em Procurar.
+DiskSpaceGBLabel=É necessário pelo menos [gb] GB de espaço livre em disco.
+DiskSpaceMBLabel=É necessário pelo menos [mb] MB de espaço livre em disco.
+CannotInstallToNetworkDrive=O Assistente de Instalação não pode instalar numa unidade de rede.
+CannotInstallToUNCPath=O Assistente de Instalação não pode instalar num caminho UNC.
+InvalidPath=É necessário indicar o caminho completo com a letra de unidade; por exemplo:%n%nC:\APP%n%nou um caminho UNC no formato:%n%n\\servidor\partilha
+InvalidDrive=A unidade ou partilha UNC seleccionada não existe ou não está acessível. Seleccione outra.
+DiskSpaceWarningTitle=Não há espaço suficiente no disco
+DiskSpaceWarning=O Assistente de Instalação necessita de pelo menos %1 KB de espaço livre, mas a unidade seleccionada tem apenas %2 KB disponíveis.%n%nDeseja continuar de qualquer forma?
+DirNameTooLong=O nome ou caminho para a pasta é demasiado longo.
+InvalidDirName=O nome da pasta não é válido.
+BadDirName32=O nome da pasta não pode conter nenhum dos seguintes caracteres:%n%n%1
+DirExistsTitle=A pasta já existe
+DirExists=A pasta:%n%n%1%n%njá existe. Pretende instalar nesta pasta?
+DirDoesntExistTitle=A pasta não existe
+DirDoesntExist=A pasta:%n%n%1%n%nnão existe. Pretende que esta pasta seja criada?
+
+; *** "Select Components" wizard page
+WizardSelectComponents=Seleccione os componentes
+SelectComponentsDesc=Que componentes deverão ser instalados?
+SelectComponentsLabel2=Seleccione os componentes que quer instalar e desseleccione os componentes que não quer instalar. Clique em Seguinte quando estiver pronto para continuar.
+FullInstallation=Instalação Completa
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=Instalação Compacta
+CustomInstallation=Instalação Personalizada
+NoUninstallWarningTitle=Componentes Encontrados
+NoUninstallWarning=O Assistente de Instalação detectou que os seguintes componentes estão instalados no seu computador:%n%n%1%n%nSe desseleccionar estes componentes eles não serão desinstalados.%n%nDeseja continuar?
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=A selecção actual necessita de pelo menos [gb] GB de espaço em disco.
+ComponentsDiskSpaceMBLabel=A selecção actual necessita de pelo menos [mb] MB de espaço em disco.
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=Seleccione tarefas adicionais
+SelectTasksDesc=Que tarefas adicionais deverão ser executadas?
+SelectTasksLabel2=Seleccione as tarefas adicionais que deseja que o Assistente de Instalação execute na instalação do [name] e em seguida clique em Seguinte.
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=Seleccione a pasta do Menu Iniciar
+SelectStartMenuFolderDesc=Onde deverão ser colocados os ícones de atalho do programa?
+SelectStartMenuFolderLabel3=Os ícones de atalho do programa serão criados na seguinte pasta do Menu Iniciar.
+SelectStartMenuFolderBrowseLabel=Para continuar, clique em Seguinte. Se desejar seleccionar uma pasta diferente, clique em Procurar.
+MustEnterGroupName=É necessário introduzir um nome para a pasta.
+GroupNameTooLong=O nome ou caminho para a pasta é demasiado longo.
+InvalidGroupName=O nome da pasta não é válido.
+BadGroupName=O nome da pasta não pode conter nenhum dos seguintes caracteres:%n%n%1
+NoProgramGroupCheck2=&Não criar nenhuma pasta no Menu Iniciar
+
+; *** "Ready to Install" wizard page
+WizardReady=Pronto para Instalar
+ReadyLabel1=O Assistente de Instalação está pronto para instalar o [name] no seu computador.
+ReadyLabel2a=Clique em Instalar para continuar a instalação, ou clique em Anterior se desejar rever ou alterar alguma das configurações.
+ReadyLabel2b=Clique em Instalar para continuar a instalação.
+ReadyMemoUserInfo=Informações do utilizador:
+ReadyMemoDir=Localização de destino:
+ReadyMemoType=Tipo de instalação:
+ReadyMemoComponents=Componentes seleccionados:
+ReadyMemoGroup=Pasta do Menu Iniciar:
+ReadyMemoTasks=Tarefas adicionais:
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel=A transferir ficheiros adicionais...
+ButtonStopDownload=&Parar transferência
+StopDownload=Tem a certeza que deseja parar a transferência?
+ErrorDownloadAborted=Transferência cancelada
+ErrorDownloadFailed=Falha na transferência: %1 %2
+ErrorDownloadSizeFailed=Falha ao obter tamanho: %1 %2
+ErrorFileHash1=Falha de verificação do ficheiro: %1
+ErrorFileHash2=Hash do ficheiro inválida: experado %1, encontrado %2
+ErrorProgress=Progresso inválido: %1 de %2
+ErrorFileSize=Tamanho de ficheiro inválido: experado %1, encontrado %2
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=Preparando-se para instalar
+PreparingDesc=Preparando-se para instalar o [name] no seu computador.
+PreviousInstallNotCompleted=A instalação/remoção de um programa anterior não foi completada. Necessitará de reiniciar o computador para completar essa instalação.%n%nDepois de reiniciar o computador, execute novamente este Assistente de Instalação para completar a instalação do [name].
+CannotContinue=A instalação não pode continuar. Clique em Cancelar para sair.
+ApplicationsFound=As seguintes aplicações estão a utilizar ficheiros que necessitam ser actualizados pelo Assistente de Instalação. É recomendado que permita que o Assistente de Instalação feche estas aplicações.
+ApplicationsFound2=As seguintes aplicações estão a utilizar ficheiros que necessitam ser actualizados pelo Assistente de Instalação. É recomendado que permita que o Assistente de Instalação feche estas aplicações. Depois de completar a instalação, o Assistente de Instalação tentará reiniciar as aplicações.
+CloseApplications=&Fechar as aplicações automaticamente
+DontCloseApplications=&Não fechar as aplicações
+ErrorCloseApplications=O Assistente de Instalação não conseguiu fechar todas as aplicações automaticamente. Antes de continuar é recomendado que feche todas as aplicações que utilizem ficheiros que necessitem de ser actualizados pelo Assistente de Instalação.
+PrepareToInstallNeedsRestart=O Assistente de Instalação necessita reiniciar o seu computador. Depois de reiniciar o computador, execute novamente o Assistente de Instalação para completar a instalação do [name].%n%nDeseja reiniciar agora?
+
+; *** "Installing" wizard page
+WizardInstalling=A instalar
+InstallingLabel=Aguarde enquanto o Assistente de Instalação instala o [name] no seu computador.
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=Instalação do [name] concluída
+FinishedLabelNoIcons=O Assistente de Instalação concluiu a instalação do [name] no seu computador.
+FinishedLabel=O Assistente de Instalação concluiu a instalação do [name] no seu computador. A aplicação pode ser iniciada através dos ícones de atalho instalados.
+ClickFinish=Clique em Concluir para finalizar o Assistente de Instalação.
+FinishedRestartLabel=Para completar a instalação do [name], o Assistente de Instalação deverá reiniciar o seu computador. Deseja reiniciar agora?
+FinishedRestartMessage=Para completar a instalação do [name], o Assistente de Instalação deverá reiniciar o seu computador.%n%nDeseja reiniciar agora?
+ShowReadmeCheck=Sim, desejo ver o ficheiro LEIAME
+YesRadio=&Sim, desejo reiniciar o computador agora
+NoRadio=&Não, desejo reiniciar o computador mais tarde
+; used for example as 'Run MyProg.exe'
+RunEntryExec=Executar %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=Visualizar %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=O Assistente de Instalação precisa do disco seguinte
+SelectDiskLabel2=Introduza o disco %1 e clique em OK.%n%nSe os ficheiros deste disco estiverem num local diferente do mostrado abaixo, indique o caminho correcto ou clique em Procurar.
+PathLabel=&Caminho:
+FileNotInDir2=O ficheiro "%1" não foi encontrado em "%2". Introduza o disco correcto ou seleccione outra pasta.
+SelectDirectoryLabel=Indique a localização do disco seguinte.
+
+; *** Installation phase messages
+SetupAborted=A instalação não está completa.%n%nCorrija o problema e execute o Assistente de Instalação novamente.
+AbortRetryIgnoreSelectAction=Seleccione uma acção
+AbortRetryIgnoreRetry=&Tentar novamente
+AbortRetryIgnoreIgnore=&Ignorar o erro e continuar
+AbortRetryIgnoreCancel=Cancelar a instalação
+
+; *** Installation status messages
+StatusClosingApplications=A fechar aplicações...
+StatusCreateDirs=A criar directorias...
+StatusExtractFiles=A extrair ficheiros...
+StatusCreateIcons=A criar atalhos...
+StatusCreateIniEntries=A criar entradas em INI...
+StatusCreateRegistryEntries=A criar entradas no registo...
+StatusRegisterFiles=A registar ficheiros...
+StatusSavingUninstall=A guardar informações para desinstalação...
+StatusRunProgram=A concluir a instalação...
+StatusRestartingApplications=A reiniciar aplicações...
+StatusRollback=A anular as alterações...
+
+; *** Misc. errors
+ErrorInternal2=Erro interno: %1
+ErrorFunctionFailedNoCode=%1 falhou
+ErrorFunctionFailed=%1 falhou; código %2
+ErrorFunctionFailedWithMessage=%1 falhou; código %2.%n%3
+ErrorExecutingProgram=Não é possível executar o ficheiro:%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=Erro ao abrir a chave de registo:%n%1\%2
+ErrorRegCreateKey=Erro ao criar a chave de registo:%n%1\%2
+ErrorRegWriteKey=Erro ao escrever na chave de registo:%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=Erro ao criar entradas em INI no ficheiro "%1".
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=&Ignorar este ficheiro (não recomendado)
+FileAbortRetryIgnoreIgnoreNotRecommended=&Ignorar este erro e continuar (não recomendado)
+SourceIsCorrupted=O ficheiro de origem está corrompido
+SourceDoesntExist=O ficheiro de origem "%1" não existe
+ExistingFileReadOnly2=O ficheiro existente não pode ser substituído porque tem o atributo "só de leitura".
+ExistingFileReadOnlyRetry=&Remover o atributo "só de leitura" e tentar novamente
+ExistingFileReadOnlyKeepExisting=&Manter o ficheiro existente
+ErrorReadingExistingDest=Ocorreu um erro ao tentar ler o ficheiro existente:
+FileExistsSelectAction=Seleccione uma acção
+FileExists2=O ficheiro já existe.
+FileExistsOverwriteExisting=&Substituir o ficheiro existente
+FileExistsKeepExisting=&Manter o ficheiro existente
+FileExistsOverwriteOrKeepAll=&Fazer isto para os próximos conflitos
+ExistingFileNewerSelectAction=Seleccione uma acção
+ExistingFileNewer2=O ficheiro existente é mais recente que o que está a ser instalado.
+ExistingFileNewerOverwriteExisting=&Substituir o ficheiro existente
+ExistingFileNewerKeepExisting=&Manter o ficheiro existente (recomendado)
+ExistingFileNewerOverwriteOrKeepAll=&Fazer isto para os próximos conflitos
+ErrorChangingAttr=Ocorreu um erro ao tentar alterar os atributos do ficheiro existente:
+ErrorCreatingTemp=Ocorreu um erro ao tentar criar um ficheiro na directoria de destino:
+ErrorReadingSource=Ocorreu um erro ao tentar ler o ficheiro de origem:
+ErrorCopying=Ocorreu um erro ao tentar copiar um ficheiro:
+ErrorReplacingExistingFile=Ocorreu um erro ao tentar substituir o ficheiro existente:
+ErrorRestartReplace=RestartReplace falhou:
+ErrorRenamingTemp=Ocorreu um erro ao tentar mudar o nome de um ficheiro na directoria de destino:
+ErrorRegisterServer=Não é possível registar o DLL/OCX: %1
+ErrorRegSvr32Failed=O RegSvr32 falhou com o código de saída %1
+ErrorRegisterTypeLib=Não foi possível registar a livraria de tipos: %1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32-bit
+UninstallDisplayNameMark64Bit=64-bit
+UninstallDisplayNameMarkAllUsers=Todos os utilizadores
+UninstallDisplayNameMarkCurrentUser=Utilizador actual
+
+; *** Post-installation errors
+ErrorOpeningReadme=Ocorreu um erro ao tentar abrir o ficheiro LEIAME.
+ErrorRestartingComputer=O Assistente de Instalação não consegue reiniciar o computador. Por favor reinicie manualmente.
+
+; *** Uninstaller messages
+UninstallNotFound=O ficheiro "%1" não existe. Não é possível desinstalar.
+UninstallOpenError=Não foi possível abrir o ficheiro "%1". Não é possível desinstalar.
+UninstallUnsupportedVer=O ficheiro log de desinstalação "%1" está num formato que não é reconhecido por esta versão do desinstalador. Não é possível desinstalar
+UninstallUnknownEntry=Foi encontrada uma entrada desconhecida (%1) no ficheiro log de desinstalação
+ConfirmUninstall=Tem a certeza que deseja remover completamente o %1 e todos os seus componentes?
+UninstallOnlyOnWin64=Esta desinstalação só pode ser realizada na versão de 64-bit's do Windows.
+OnlyAdminCanUninstall=Esta desinstalação só pode ser realizada por um utilizador com privilégios administrativos.
+UninstallStatusLabel=Por favor aguarde enquanto o %1 está a ser removido do seu computador.
+UninstalledAll=O %1 foi removido do seu computador com sucesso.
+UninstalledMost=A desinstalação do %1 está concluída.%n%nAlguns elementos não puderam ser removidos. Estes elementos podem ser removidos manualmente.
+UninstalledAndNeedsRestart=Para completar a desinstalação do %1, o computador deve ser reiniciado.%n%nDeseja reiniciar agora?
+UninstallDataCorrupted=O ficheiro "%1" está corrompido. Não é possível desinstalar
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=Remover ficheiro partilhado?
+ConfirmDeleteSharedFile2=O sistema indica que o seguinte ficheiro partilhado já não está a ser utilizado por nenhum programa. Deseja removê-lo?%n%nSe algum programa ainda necessitar deste ficheiro, poderá não funcionar correctamente depois de o remover. Se não tiver a certeza, seleccione Não. Manter o ficheiro não causará nenhum problema.
+SharedFileNameLabel=Nome do ficheiro:
+SharedFileLocationLabel=Localização:
+WizardUninstalling=Estado da desinstalação
+StatusUninstalling=A desinstalar o %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=A instalar %1.
+ShutdownBlockReasonUninstallingApp=A desinstalar %1.
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 versão %2
+AdditionalIcons=Atalhos adicionais:
+CreateDesktopIcon=Criar atalho no Ambiente de &Trabalho
+CreateQuickLaunchIcon=&Criar atalho na barra de Iniciação Rápida
+ProgramOnTheWeb=%1 na Web
+UninstallProgram=Desinstalar o %1
+LaunchProgram=Executar o %1
+AssocFileExtension=Associa&r o %1 aos ficheiros com a extensão %2
+AssocingFileExtension=A associar o %1 aos ficheiros com a extensão %2...
+AutoStartProgramGroupDescription=Inicialização Automática:
+AutoStartProgram=Iniciar %1 automaticamente
+AddonHostProgramNotFound=Não foi possível localizar %1 na pasta seleccionada.%n%nDeseja continuar de qualquer forma?

--- a/deploy/languages/Russian.isl
+++ b/deploy/languages/Russian.isl
@@ -1,0 +1,370 @@
+; *** Inno Setup version 6.1.0+ Russian messages ***
+;
+; Translated from English by Dmitry Kann, yktooo at gmail.com
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+
+[LangOptions]
+LanguageName=<0420><0443><0441><0441><043A><0438><0439>
+LanguageID=$0419
+LanguageCodePage=1251
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=Установка
+SetupWindowTitle=Установка — %1
+UninstallAppTitle=Деинсталляция
+UninstallAppFullTitle=Деинсталляция — %1
+
+; *** Misc. common
+InformationTitle=Информация
+ConfirmTitle=Подтверждение
+ErrorTitle=Ошибка
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=Данная программа установит %1 на ваш компьютер, продолжить?
+LdrCannotCreateTemp=Невозможно создать временный файл. Установка прервана
+LdrCannotExecTemp=Невозможно выполнить файл во временном каталоге. Установка прервана
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1.%n%nОшибка %2: %3
+SetupFileMissing=Файл %1 отсутствует в папке установки. Пожалуйста, устраните проблему или получите новую версию программы.
+SetupFileCorrupt=Установочные файлы повреждены. Пожалуйста, получите новую копию программы.
+SetupFileCorruptOrWrongVer=Эти установочные файлы повреждены или несовместимы с данной версией программы установки. Пожалуйста, устраните проблему или получите новую копию программы.
+InvalidParameter=Командная строка содержит недопустимый параметр:%n%n%1
+SetupAlreadyRunning=Программа установки уже запущена.
+WindowsVersionNotSupported=Эта программа не поддерживает версию Windows, установленную на этом компьютере.
+WindowsServicePackRequired=Эта программа требует %1 Service Pack %2 или более позднюю версию.
+NotOnThisPlatform=Эта программа не будет работать в %1.
+OnlyOnThisPlatform=Эту программу можно запускать только в %1.
+OnlyOnTheseArchitectures=Установка этой программы возможна только в версиях Windows для следующих архитектур процессоров:%n%n%1
+WinVersionTooLowError=Эта программа требует %1 версии %2 или выше.
+WinVersionTooHighError=Программа не может быть установлена в %1 версии %2 или выше.
+AdminPrivilegesRequired=Чтобы установить данную программу, вы должны выполнить вход в систему как Администратор.
+PowerUserPrivilegesRequired=Чтобы установить эту программу, вы должны выполнить вход в систему как Администратор или член группы «Опытные пользователи» (Power Users).
+SetupAppRunningError=Обнаружен запущенный экземпляр %1.%n%nПожалуйста, закройте все экземпляры приложения, затем нажмите «OK», чтобы продолжить, или «Отмена», чтобы выйти.
+UninstallAppRunningError=Деинсталлятор обнаружил запущенный экземпляр %1.%n%nПожалуйста, закройте все экземпляры приложения, затем нажмите «OK», чтобы продолжить, или «Отмена», чтобы выйти.
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=Выбор режима установки
+PrivilegesRequiredOverrideInstruction=Выберите режим установки
+PrivilegesRequiredOverrideText1=%1 может быть установлена либо для всех пользователей (требуются привилегии администратора), либо только для вас.
+PrivilegesRequiredOverrideText2=%1 может быть установлена либо только для вас, либо для всех пользователей (требуются привилегии администратора).
+PrivilegesRequiredOverrideAllUsers=Установить для &всех пользователей
+PrivilegesRequiredOverrideAllUsersRecommended=Установить для &всех пользователей (рекомендуется)
+PrivilegesRequiredOverrideCurrentUser=Установить только для &меня
+PrivilegesRequiredOverrideCurrentUserRecommended=Установить только для &меня (рекомендуется)
+
+; *** Misc. errors
+ErrorCreatingDir=Невозможно создать папку "%1"
+ErrorTooManyFilesInDir=Невозможно создать файл в каталоге "%1", так как в нём слишком много файлов
+
+; *** Setup common messages
+ExitSetupTitle=Выход из программы установки
+ExitSetupMessage=Установка не завершена. Если вы выйдете, программа не будет установлена.%n%nВы сможете завершить установку, запустив программу установки позже.%n%nВыйти из программы установки?
+AboutSetupMenuItem=&О программе...
+AboutSetupTitle=О программе
+AboutSetupMessage=%1, версия %2%n%3%n%nСайт %1:%n%4
+AboutSetupNote=
+TranslatorNote=Russian translation by Dmitry Kann, http://www.dk-soft.org/
+
+; *** Buttons
+ButtonBack=< &Назад
+ButtonNext=&Далее >
+ButtonInstall=&Установить
+ButtonOK=OK
+ButtonCancel=Отмена
+ButtonYes=&Да
+ButtonYesToAll=Да для &Всех
+ButtonNo=&Нет
+ButtonNoToAll=Н&ет для Всех
+ButtonFinish=&Завершить
+ButtonBrowse=&Обзор...
+ButtonWizardBrowse=&Обзор...
+ButtonNewFolder=&Создать папку
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=Выберите язык установки
+SelectLanguageLabel=Выберите язык, который будет использован в процессе установки.
+
+; *** Common wizard text
+ClickNext=Нажмите «Далее», чтобы продолжить, или «Отмена», чтобы выйти из программы установки.
+BeveledLabel=
+BrowseDialogTitle=Обзор папок
+BrowseDialogLabel=Выберите папку из списка и нажмите «ОК».
+NewFolderName=Новая папка
+
+; *** "Welcome" wizard page
+WelcomeLabel1=Вас приветствует Мастер установки [name]
+WelcomeLabel2=Программа установит [name/ver] на ваш компьютер.%n%nРекомендуется закрыть все прочие приложения перед тем, как продолжить.
+
+; *** "Password" wizard page
+WizardPassword=Пароль
+PasswordLabel1=Эта программа защищена паролем.
+PasswordLabel3=Пожалуйста, наберите пароль, потом нажмите «Далее». Пароли необходимо вводить с учётом регистра.
+PasswordEditLabel=&Пароль:
+IncorrectPassword=Введенный вами пароль неверен. Пожалуйста, попробуйте снова.
+
+; *** "License Agreement" wizard page
+WizardLicense=Лицензионное Соглашение
+LicenseLabel=Пожалуйста, прочтите следующую важную информацию перед тем, как продолжить.
+LicenseLabel3=Пожалуйста, прочтите следующее Лицензионное Соглашение. Вы должны принять условия этого соглашения перед тем, как продолжить.
+LicenseAccepted=Я &принимаю условия соглашения
+LicenseNotAccepted=Я &не принимаю условия соглашения
+
+; *** "Information" wizard pages
+WizardInfoBefore=Информация
+InfoBeforeLabel=Пожалуйста, прочитайте следующую важную информацию перед тем, как продолжить.
+InfoBeforeClickLabel=Когда вы будете готовы продолжить установку, нажмите «Далее».
+WizardInfoAfter=Информация
+InfoAfterLabel=Пожалуйста, прочитайте следующую важную информацию перед тем, как продолжить.
+InfoAfterClickLabel=Когда вы будете готовы продолжить установку, нажмите «Далее».
+
+; *** "User Information" wizard page
+WizardUserInfo=Информация о пользователе
+UserInfoDesc=Пожалуйста, введите данные о себе.
+UserInfoName=&Имя и фамилия пользователя:
+UserInfoOrg=&Организация:
+UserInfoSerial=&Серийный номер:
+UserInfoNameRequired=Вы должны ввести имя.
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=Выбор папки установки
+SelectDirDesc=В какую папку вы хотите установить [name]?
+SelectDirLabel3=Программа установит [name] в следующую папку.
+SelectDirBrowseLabel=Нажмите «Далее», чтобы продолжить. Если вы хотите выбрать другую папку, нажмите «Обзор».
+DiskSpaceGBLabel=Требуется как минимум [gb] Гб свободного дискового пространства.
+DiskSpaceMBLabel=Требуется как минимум [mb] Мб свободного дискового пространства.
+CannotInstallToNetworkDrive=Установка не может производиться на сетевой диск.
+CannotInstallToUNCPath=Установка не может производиться в папку по UNC-пути.
+InvalidPath=Вы должны указать полный путь с буквой диска; например:%n%nC:\APP%n%nили в форме UNC:%n%n\\имя_сервера\имя_ресурса
+InvalidDrive=Выбранный вами диск или сетевой путь не существует или недоступен. Пожалуйста, выберите другой.
+DiskSpaceWarningTitle=Недостаточно места на диске
+DiskSpaceWarning=Установка требует не менее %1 Кб свободного места, а на выбранном вами диске доступно только %2 Кб.%n%nВы желаете тем не менее продолжить установку?
+DirNameTooLong=Имя папки или путь к ней превышают допустимую длину.
+InvalidDirName=Указанное имя папки недопустимо.
+BadDirName32=Имя папки не может содержать символов: %n%n%1
+DirExistsTitle=Папка существует
+DirExists=Папка%n%n%1%n%nуже существует. Всё равно установить в эту папку?
+DirDoesntExistTitle=Папка не существует
+DirDoesntExist=Папка%n%n%1%n%nне существует. Вы хотите создать её?
+
+; *** "Select Components" wizard page
+WizardSelectComponents=Выбор компонентов
+SelectComponentsDesc=Какие компоненты должны быть установлены?
+SelectComponentsLabel2=Выберите компоненты, которые вы хотите установить; снимите флажки с компонентов, устанавливать которые не требуется. Нажмите «Далее», когда вы будете готовы продолжить.
+FullInstallation=Полная установка
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=Компактная установка
+CustomInstallation=Выборочная установка
+NoUninstallWarningTitle=Установленные компоненты
+NoUninstallWarning=Программа установки обнаружила, что следующие компоненты уже установлены на вашем компьютере:%n%n%1%n%nОтмена выбора этих компонентов не удалит их.%n%nПродолжить?
+ComponentSize1=%1 Кб
+ComponentSize2=%1 Мб
+ComponentsDiskSpaceGBLabel=Текущий выбор требует не менее [gb] Гб на диске.
+ComponentsDiskSpaceMBLabel=Текущий выбор требует не менее [mb] Мб на диске.
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=Выберите дополнительные задачи
+SelectTasksDesc=Какие дополнительные задачи необходимо выполнить?
+SelectTasksLabel2=Выберите дополнительные задачи, которые должны выполниться при установке [name], после этого нажмите «Далее»:
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=Выберите папку в меню «Пуск»
+SelectStartMenuFolderDesc=Где программа установки должна создать ярлыки?
+SelectStartMenuFolderLabel3=Программа создаст ярлыки в следующей папке меню «Пуск».
+SelectStartMenuFolderBrowseLabel=Нажмите «Далее», чтобы продолжить. Если вы хотите выбрать другую папку, нажмите «Обзор».
+MustEnterGroupName=Вы должны ввести имя папки.
+GroupNameTooLong=Имя папки группы или путь к ней превышают допустимую длину.
+InvalidGroupName=Указанное имя папки недопустимо.
+BadGroupName=Имя папки не может содержать символов:%n%n%1
+NoProgramGroupCheck2=&Не создавать папку в меню «Пуск»
+
+; *** "Ready to Install" wizard page
+WizardReady=Всё готово к установке
+ReadyLabel1=Программа установки готова начать установку [name] на ваш компьютер.
+ReadyLabel2a=Нажмите «Установить», чтобы продолжить, или «Назад», если вы хотите просмотреть или изменить опции установки.
+ReadyLabel2b=Нажмите «Установить», чтобы продолжить.
+ReadyMemoUserInfo=Информация о пользователе:
+ReadyMemoDir=Папка установки:
+ReadyMemoType=Тип установки:
+ReadyMemoComponents=Выбранные компоненты:
+ReadyMemoGroup=Папка в меню «Пуск»:
+ReadyMemoTasks=Дополнительные задачи:
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel=Загрузка дополнительных файлов...
+ButtonStopDownload=&Прервать загрузку
+StopDownload=Вы действительно хотите прекратить загрузку?
+ErrorDownloadAborted=Загрузка прервана
+ErrorDownloadFailed=Ошибка загрузки: %1 %2
+ErrorDownloadSizeFailed=Ошибка получения размера: %1 %2
+ErrorFileHash1=Ошибка хэша файла: %1
+ErrorFileHash2=Неверный хэш файла: ожидался %1, получен %2
+ErrorProgress=Ошибка выполнения: %1 из %2
+ErrorFileSize=Неверный размер файла: ожидался %1, получен %2
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=Подготовка к установке
+PreparingDesc=Программа установки подготавливается к установке [name] на ваш компьютер.
+PreviousInstallNotCompleted=Установка или удаление предыдущей программы не были завершены. Вам потребуется перезагрузить компьютер, чтобы завершить ту установку.%n%nПосле перезагрузки запустите вновь Программу установки, чтобы завершить установку [name].
+CannotContinue=Невозможно продолжить установку. Нажмите «Отмена» для выхода из программы.
+ApplicationsFound=Следующие приложения используют файлы, которые программа установки должна обновить. Рекомендуется позволить программе установки автоматически закрыть эти приложения.
+ApplicationsFound2=Следующие приложения используют файлы, которые программа установки должна обновить. Рекомендуется позволить программе установки автоматически закрыть эти приложения. Когда установка будет завершена, программа установки попытается вновь запустить их.
+CloseApplications=&Автоматически закрыть эти приложения
+DontCloseApplications=&Не закрывать эти приложения
+ErrorCloseApplications=Программе установки не удалось автоматически закрыть все приложения. Рекомендуется закрыть все приложения, которые используют подлежащие обновлению файлы, прежде чем продолжить установку.
+PrepareToInstallNeedsRestart=Программе установки требуется перезагрузить ваш компьютер. Когда перезагрузка завершится, пожалуйста, запустите программу установки вновь, чтобы завершить процесс установки [name].%n%nПроизвести перезагрузку сейчас?
+
+; *** "Installing" wizard page
+WizardInstalling=Установка...
+InstallingLabel=Пожалуйста, подождите, пока [name] установится на ваш компьютер.
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=Завершение Мастера установки [name]
+FinishedLabelNoIcons=Программа [name] установлена на ваш компьютер.
+FinishedLabel=Программа [name] установлена на ваш компьютер. Приложение можно запустить с помощью соответствующего значка.
+ClickFinish=Нажмите «Завершить», чтобы выйти из программы установки.
+FinishedRestartLabel=Для завершения установки [name] требуется перезагрузить компьютер. Произвести перезагрузку сейчас?
+FinishedRestartMessage=Для завершения установки [name] требуется перезагрузить компьютер.%n%nПроизвести перезагрузку сейчас?
+ShowReadmeCheck=Я хочу просмотреть файл README
+YesRadio=&Да, перезагрузить компьютер сейчас
+NoRadio=&Нет, я произведу перезагрузку позже
+; used for example as 'Run MyProg.exe'
+RunEntryExec=Запустить %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=Просмотреть %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=Необходимо вставить следующий диск
+SelectDiskLabel2=Пожалуйста, вставьте диск %1 и нажмите «OK».%n%nЕсли файлы этого диска могут быть найдены в папке, отличающейся от показанной ниже, введите правильный путь или нажмите «Обзор».
+PathLabel=&Путь:
+FileNotInDir2=Файл "%1" не найден в "%2". Пожалуйста, вставьте правильный диск или выберите другую папку.
+SelectDirectoryLabel=Пожалуйста, укажите путь к следующему диску.
+
+; *** Installation phase messages
+SetupAborted=Установка не была завершена.%n%nПожалуйста, устраните проблему и запустите установку снова.
+AbortRetryIgnoreSelectAction=Выберите действие
+AbortRetryIgnoreRetry=Попробовать &снова
+AbortRetryIgnoreIgnore=&Игнорировать ошибку и продолжить
+AbortRetryIgnoreCancel=Отменить установку
+
+; *** Installation status messages
+StatusClosingApplications=Закрытие приложений...
+StatusCreateDirs=Создание папок...
+StatusExtractFiles=Распаковка файлов...
+StatusCreateIcons=Создание ярлыков программы...
+StatusCreateIniEntries=Создание INI-файлов...
+StatusCreateRegistryEntries=Создание записей реестра...
+StatusRegisterFiles=Регистрация файлов...
+StatusSavingUninstall=Сохранение информации для деинсталляции...
+StatusRunProgram=Завершение установки...
+StatusRestartingApplications=Перезапуск приложений...
+StatusRollback=Откат изменений...
+
+; *** Misc. errors
+ErrorInternal2=Внутренняя ошибка: %1
+ErrorFunctionFailedNoCode=%1: сбой
+ErrorFunctionFailed=%1: сбой; код %2
+ErrorFunctionFailedWithMessage=%1: сбой; код %2.%n%3
+ErrorExecutingProgram=Невозможно выполнить файл:%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=Ошибка открытия ключа реестра:%n%1\%2
+ErrorRegCreateKey=Ошибка создания ключа реестра:%n%1\%2
+ErrorRegWriteKey=Ошибка записи в ключ реестра:%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=Ошибка создания записи в INI-файле "%1".
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=&Пропустить этот файл (не рекомендуется)
+FileAbortRetryIgnoreIgnoreNotRecommended=&Игнорировать ошибку и продолжить (не рекомендуется)
+SourceIsCorrupted=Исходный файл поврежден
+SourceDoesntExist=Исходный файл "%1" не существует
+ExistingFileReadOnly2=Невозможно заменить существующий файл, так как он помечен как «файл только для чтения».
+ExistingFileReadOnlyRetry=&Удалить атрибут «только для чтения» и повторить попытку
+ExistingFileReadOnlyKeepExisting=&Оставить файл на месте
+ErrorReadingExistingDest=Произошла ошибка при попытке чтения существующего файла:
+FileExistsSelectAction=Выберите действие
+FileExists2=Файл уже существует.
+FileExistsOverwriteExisting=&Заменить существующий файл
+FileExistsKeepExisting=&Сохранить существующий файл
+FileExistsOverwriteOrKeepAll=&Повторить действие для всех последующих конфликтов
+ExistingFileNewerSelectAction=Выберите действие
+ExistingFileNewer2=Существующий файл более новый, чем устанавливаемый.
+ExistingFileNewerOverwriteExisting=&Заменить существующий файл
+ExistingFileNewerKeepExisting=&Сохранить существующий файл (рекомендуется)
+ExistingFileNewerOverwriteOrKeepAll=&Повторить действие для всех последующих конфликтов
+ErrorChangingAttr=Произошла ошибка при попытке изменения атрибутов существующего файла:
+ErrorCreatingTemp=Произошла ошибка при попытке создания файла в папке назначения:
+ErrorReadingSource=Произошла ошибка при попытке чтения исходного файла:
+ErrorCopying=Произошла ошибка при попытке копирования файла:
+ErrorReplacingExistingFile=Произошла ошибка при попытке замены существующего файла:
+ErrorRestartReplace=Ошибка RestartReplace:
+ErrorRenamingTemp=Произошла ошибка при попытке переименования файла в папке назначения:
+ErrorRegisterServer=Невозможно зарегистрировать DLL/OCX: %1
+ErrorRegSvr32Failed=Ошибка при выполнении RegSvr32, код возврата %1
+ErrorRegisterTypeLib=Невозможно зарегистрировать библиотеку типов (Type Library): %1
+
+; *** Uninstall display name markings
+UninstallDisplayNameMark=%1 (%2)
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32 бита
+UninstallDisplayNameMark64Bit=64 бита
+UninstallDisplayNameMarkAllUsers=Все пользователи
+UninstallDisplayNameMarkCurrentUser=Текущий пользователь
+
+; *** Post-installation errors
+ErrorOpeningReadme=Произошла ошибка при попытке открытия файла README.
+ErrorRestartingComputer=Программе установки не удалось перезапустить компьютер. Пожалуйста, выполните это самостоятельно.
+
+; *** Uninstaller messages
+UninstallNotFound=Файл "%1" не существует, деинсталляция невозможна.
+UninstallOpenError=Невозможно открыть файл "%1". Деинсталляция невозможна
+UninstallUnsupportedVer=Файл протокола для деинсталляции "%1" не распознан данной версией программы-деинсталлятора. Деинсталляция невозможна
+UninstallUnknownEntry=Встретился неизвестный пункт (%1) в файле протокола для деинсталляции
+ConfirmUninstall=Вы действительно хотите удалить %1 и все компоненты программы?
+UninstallOnlyOnWin64=Данную программу возможно деинсталлировать только в среде 64-битной Windows.
+OnlyAdminCanUninstall=Эта программа может быть деинсталлирована только пользователем с административными привилегиями.
+UninstallStatusLabel=Пожалуйста, подождите, пока %1 будет удалена с вашего компьютера.
+UninstalledAll=Программа %1 была полностью удалена с вашего компьютера.
+UninstalledMost=Деинсталляция %1 завершена.%n%nЧасть элементов не удалось удалить. Вы можете удалить их самостоятельно.
+UninstalledAndNeedsRestart=Для завершения деинсталляции %1 необходимо произвести перезагрузку вашего компьютера.%n%nВыполнить перезагрузку сейчас?
+UninstallDataCorrupted=Файл "%1" поврежден. Деинсталляция невозможна
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=Удалить совместно используемый файл?
+ConfirmDeleteSharedFile2=Система указывает, что следующий совместно используемый файл больше не используется никакими другими приложениями. Подтверждаете удаление файла?%n%nЕсли какие-либо программы всё еще используют этот файл, и он будет удалён, они не смогут работать правильно. Если Вы не уверены, выберите «Нет». Оставленный файл не навредит вашей системе.
+SharedFileNameLabel=Имя файла:
+SharedFileLocationLabel=Расположение:
+WizardUninstalling=Состояние деинсталляции
+StatusUninstalling=Деинсталляция %1...
+
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=Установка %1.
+ShutdownBlockReasonUninstallingApp=Деинсталляция %1.
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1, версия %2
+AdditionalIcons=Дополнительные значки:
+CreateDesktopIcon=Создать значок на &Рабочем столе
+CreateQuickLaunchIcon=Создать значок в &Панели быстрого запуска
+ProgramOnTheWeb=Сайт %1 в Интернете
+UninstallProgram=Деинсталлировать %1
+LaunchProgram=Запустить %1
+AssocFileExtension=Св&язать %1 с файлами, имеющими расширение %2
+AssocingFileExtension=Связывание %1 с файлами %2...
+AutoStartProgramGroupDescription=Автозапуск:
+AutoStartProgram=Автоматически запускать %1
+AddonHostProgramNotFound=%1 не найден в указанной вами папке.%n%nВы всё равно хотите продолжить?

--- a/deploy/languages/Slovenian.isl
+++ b/deploy/languages/Slovenian.isl
@@ -1,0 +1,370 @@
+; *** Inno Setup version 6.1.0+ Slovenian messages ***
+;
+; To download user-contributed translations of this file, go to:
+;   http://www.jrsoftware.org/is3rdparty.php
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+;
+; Maintained by Jernej Simoncic (jernej+s-innosetup@eternallybored.org)
+
+[LangOptions]
+LanguageName=Slovenski
+LanguageID=$0424
+LanguageCodePage=1250
+
+DialogFontName=
+[Messages]
+
+; *** Application titles
+SetupAppTitle=Namestitev
+SetupWindowTitle=Namestitev - %1
+UninstallAppTitle=Odstranitev
+UninstallAppFullTitle=Odstranitev programa %1
+
+; *** Misc. common
+InformationTitle=Informacija
+ConfirmTitle=Potrditev
+ErrorTitle=Napaka
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=V raèunalnik boste namestili program %1. Želite nadaljevati?
+LdrCannotCreateTemp=Ni bilo mogoèe ustvariti zaèasne datoteke. Namestitev je prekinjena
+LdrCannotExecTemp=Ni bilo mogoèe zagnati datoteke v zaèasni mapi. Namestitev je prekinjena
+
+; *** Startup error messages
+LastErrorMessage=%1.%n%nNapaka %2: %3
+SetupFileMissing=Datoteka %1 manjka. Odpravite napako ali si priskrbite drugo kopijo programa.
+SetupFileCorrupt=Datoteke namestitvenega programa so okvarjene. Priskrbite si drugo kopijo programa.
+SetupFileCorruptOrWrongVer=Datoteke so okvarjene ali nezdružljive s to razlièico namestitvenega programa. Odpravite napako ali si priskrbite drugo kopijo programa.
+InvalidParameter=Naveden je bil napaèen parameter ukazne vrstice:%n%n%1
+SetupAlreadyRunning=Namestitveni program se že izvaja.
+WindowsVersionNotSupported=Program ne deluje na vaši razlièici sistema Windows.
+WindowsServicePackRequired=Program potrebuje %1 s servisnim paketom %2 ali novejšo razlièico.
+NotOnThisPlatform=Program ni namenjen za uporabo v %1.
+OnlyOnThisPlatform=Program je namenjen le za uporabo v %1.
+OnlyOnTheseArchitectures=Program lahko namestite le na Windows sistemih, na naslednjih vrstah procesorjev:%n%n%1
+WinVersionTooLowError=Ta program zahteva %1 razlièico %2 ali novejšo.
+WinVersionTooHighError=Tega programa ne morete namestiti v %1 razlièice %2 ali novejše.
+AdminPrivilegesRequired=Za namestitev programa morate biti prijavljeni v raèun s skrbniškimi pravicami.
+PowerUserPrivilegesRequired=Za namestitev programa morate biti prijavljeni v raèun s skrbniškimi ali power user pravicami.
+SetupAppRunningError=Program %1 je trenutno odprt.%n%nZaprite program, nato kliknite V redu za nadaljevanje ali Preklièi za izhod.
+UninstallAppRunningError=Program %1 je trenutno odprt.%n%nZaprite program, nato kliknite V redu za nadaljevanje ali Preklièi za izhod.
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=Izberite naèin namestitve
+PrivilegesRequiredOverrideInstruction=Izberite naèin namestitve
+PrivilegesRequiredOverrideText1=Program %1 lahko namestite za vse uporabnike (potrebujete skrbniške pravice), ali pa samo za vas.
+PrivilegesRequiredOverrideText2=Program %1 lahko namestite samo za vas, ali pa za vse uporabnike (potrebujete skrbniške pravice).
+PrivilegesRequiredOverrideAllUsers=N&amesti za vse uporabnike
+PrivilegesRequiredOverrideAllUsersRecommended=N&amesti za vse uporabnike (priporoèeno)
+PrivilegesRequiredOverrideCurrentUser=Namesti samo za&me
+PrivilegesRequiredOverrideCurrentUserRecommended=Namesti samo za&me (priporoèeno)
+
+; *** Misc. errors
+ErrorCreatingDir=Namestitveni program ni mogel ustvariti mape »%1«
+ErrorTooManyFilesInDir=Namestitveni program ne more ustvariti nove datoteke v mapi »%1«, ker vsebuje preveè datotek
+
+; *** Setup common messages
+ExitSetupTitle=Prekini namestitev
+ExitSetupMessage=Namestitev ni konèana. Èe jo boste prekinili, program ne bo namešèen.%n%nPonovno namestitev lahko izvedete kasneje.%n%nŽelite prekiniti namestitev?
+AboutSetupMenuItem=&O namestitvenem programu...
+AboutSetupTitle=O namestitvenem programu
+AboutSetupMessage=%1 razlièica %2%n%3%n%n%1 domaèa stran:%n%4
+AboutSetupNote=
+TranslatorNote=Slovenski prevod:%nMiha Remec%nJernej Simonèiè <jernej|s-innosetup@eternallybored.org>
+
+; *** Buttons
+ButtonBack=< Na&zaj
+ButtonNext=&Naprej >
+ButtonInstall=&Namesti
+ButtonOK=V redu
+ButtonCancel=Preklièi
+ButtonYes=&Da
+ButtonYesToAll=Da za &vse
+ButtonNo=&Ne
+ButtonNoToAll=N&e za vse
+ButtonFinish=&Konèaj
+ButtonBrowse=Pre&brskaj...
+ButtonWizardBrowse=Pre&brskaj...
+ButtonNewFolder=&Ustvari novo mapo
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=Izbira jezika namestitve
+SelectLanguageLabel=Izberite jezik, ki ga želite uporabljati med namestitvijo.
+
+; *** Common wizard text
+ClickNext=Kliknite Naprej za nadaljevanje namestitve ali Preklièi za prekinitev namestitve.
+BeveledLabel=
+BrowseDialogTitle=Izbira mape
+BrowseDialogLabel=Izberite mapo s spiska, nato kliknite V redu.
+NewFolderName=Nova mapa
+
+; *** "Welcome" wizard page
+WelcomeLabel1=Dobrodošli v namestitev programa [name].
+WelcomeLabel2=V raèunalnik boste namestili program [name/ver].%n%nPriporoèljivo je, da pred zaèetkom namestitve zaprete vse odprte programe.
+
+; *** "Password" wizard page
+WizardPassword=Geslo
+PasswordLabel1=Namestitev je zašèitena z geslom.
+PasswordLabel3=Vnesite geslo, nato kliknite Naprej za nadaljevanje. Pri vnašanju pazite na male in velike èrke.
+PasswordEditLabel=&Geslo:
+IncorrectPassword=Vneseno geslo ni pravilno. Poizkusite ponovno.
+
+; *** "License Agreement" wizard page
+WizardLicense=Licenèna pogodba
+LicenseLabel=Pred nadaljevanjem preberite licenèno pogodbo za uporabo programa.
+LicenseLabel3=Preberite licenèno pogodbo za uporabo programa. Program lahko namestite le, èe se s pogodbo v celoti strinjate.
+LicenseAccepted=&Da, sprejemam vse pogoje licenène pogodbe
+LicenseNotAccepted=N&e, pogojev licenène pogodbe ne sprejmem
+
+; *** "Information" wizard pages
+WizardInfoBefore=Informacije
+InfoBeforeLabel=Pred nadaljevanjem preberite naslednje pomembne informacije.
+InfoBeforeClickLabel=Ko boste pripravljeni na nadaljevanje namestitve, kliknite Naprej.
+WizardInfoAfter=Informacije
+InfoAfterLabel=Pred nadaljevanjem preberite naslednje pomembne informacije.
+InfoAfterClickLabel=Ko boste pripravljeni na nadaljevanje namestitve, kliknite Naprej.
+
+; *** "User Information" wizard page
+WizardUserInfo=Podatki o uporabniku
+UserInfoDesc=Vnesite svoje podatke.
+UserInfoName=&Ime:
+UserInfoOrg=&Podjetje:
+UserInfoSerial=&Serijska številka:
+UserInfoNameRequired=Vnos imena je obvezen.
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=Izbira ciljnega mesta
+SelectDirDesc=Kam želite namestiti program [name]?
+SelectDirLabel3=Program [name] bo namešèen v naslednjo mapo.
+SelectDirBrowseLabel=Za nadaljevanje kliknite Naprej. Èe želite izbrati drugo mapo, kliknite Prebrskaj.
+DiskSpaceGBLabel=Na disku mora biti vsaj [gb] GB prostora.
+DiskSpaceMBLabel=Na disku mora biti vsaj [mb] MB prostora.
+CannotInstallToNetworkDrive=Programa ni mogoèe namestiti na mrežni pogon.
+CannotInstallToUNCPath=Programa ni mogoèe namestiti v UNC pot.
+InvalidPath=Vpisati morate polno pot vkljuèno z oznako pogona. Primer:%n%nC:\PROGRAM%n%nali UNC pot v obliki:%n%n\\strežnik\mapa_skupne_rabe
+InvalidDrive=Izbrani pogon ali omrežno sredstvo UNC ne obstaja ali ni dostopno. Izberite drugega.
+DiskSpaceWarningTitle=Na disku ni dovolj prostora
+DiskSpaceWarning=Namestitev potrebuje vsaj %1 KB prostora, toda na izbranem pogonu je na voljo le %2 KB.%n%nŽelite kljub temu nadaljevati?
+DirNameTooLong=Ime mape ali poti je predolgo.
+InvalidDirName=Ime mape ni veljavno.
+BadDirName32=Ime mape ne sme vsebovati naslednjih znakov:%n%n%1
+DirExistsTitle=Mapa že obstaja
+DirExists=Mapa%n%n%1%n%nže obstaja. Želite program vseeno namestiti v to mapo?
+DirDoesntExistTitle=Mapa ne obstaja
+DirDoesntExist=Mapa %n%n%1%n%nne obstaja. Ali jo želite ustvariti?
+
+; *** "Select Components" wizard page
+WizardSelectComponents=Izbira komponent
+SelectComponentsDesc=Katere komponente želite namestiti?
+SelectComponentsLabel2=Oznaèite komponente, ki jih želite namestiti; odznaèite komponente, ki jih ne želite namestiti. Kliknite Naprej, ko boste pripravljeni za nadaljevanje.
+FullInstallation=Popolna namestitev
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=Osnovna namestitev
+CustomInstallation=Namestitev po meri
+NoUninstallWarningTitle=Komponente že obstajajo
+NoUninstallWarning=Namestitveni program je ugotovil, da so naslednje komponente že namešèene v raèunalniku:%n%n%1%n%nNamestitveni program teh že namešèenih komponent ne bo odstranil.%n%nŽelite vseeno nadaljevati?
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=Za izbrano namestitev potrebujete vsaj [gb] GB prostora na disku.
+ComponentsDiskSpaceMBLabel=Za izbrano namestitev potrebujete vsaj [mb] MB prostora na disku.
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=Izbira dodatnih opravil
+SelectTasksDesc=Katera dodatna opravila želite izvesti?
+SelectTasksLabel2=Izberite dodatna opravila, ki jih bo namestitveni program opravil med namestitvijo programa [name], nato kliknite Naprej.
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=Izbira mape v meniju »Zaèetek«
+SelectStartMenuFolderDesc=Kje naj namestitveni program ustvari bližnjice?
+SelectStartMenuFolderLabel3=Namestitveni program bo ustvaril bližnjice v naslednji mapi v meniju »Start«.
+SelectStartMenuFolderBrowseLabel=Za nadaljevanje kliknite Naprej. Èe želite izbrati drugo mapo, kliknite Prebrskaj.
+MustEnterGroupName=Ime skupine mora biti vpisano.
+GroupNameTooLong=Ime mape ali poti je predolgo.
+InvalidGroupName=Ime mape ni veljavno.
+BadGroupName=Ime skupine ne sme vsebovati naslednjih znakov:%n%n%1
+NoProgramGroupCheck2=&Ne ustvari mape v meniju »Start«
+
+; *** "Ready to Install" wizard page
+WizardReady=Pripravljen za namestitev
+ReadyLabel1=Namestitveni program je pripravljen za namestitev programa [name] v vaš raèunalnik.
+ReadyLabel2a=Kliknite Namesti za zaèetek namešèanja. Kliknite Nazaj, èe želite pregledati ali spremeniti katerokoli nastavitev.
+ReadyLabel2b=Kliknite Namesti za zaèetek namešèanja.
+ReadyMemoUserInfo=Podatki o uporabniku:
+ReadyMemoDir=Ciljno mesto:
+ReadyMemoType=Vrsta namestitve:
+ReadyMemoComponents=Izbrane komponente:
+ReadyMemoGroup=Mapa v meniju »Zaèetek«:
+ReadyMemoTasks=Dodatna opravila:
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel=Prenašam dodatne datoteke...
+ButtonStopDownload=Prekini preno&s
+StopDownload=Ali res želite prekiniti prenos?
+ErrorDownloadAborted=Prenos prekinjen
+ErrorDownloadFailed=Prenos ni uspel: %1 %2
+ErrorDownloadSizeFailed=Pridobivanje velikosti ni uspelo: %1 %2
+ErrorFileHash1=Pridobivanje zgošèene vrednosti ni uspelo: %1
+ErrorFileHash2=Neveljavna zgošèena vrednost: prièakovana %1, dobljena %2
+ErrorProgress=Neveljaven potek: %1 od %2
+ErrorFileSize=Neveljavna velikost datoteke: prièakovana %1, dobljena %2
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=Pripravljam za namestitev
+PreparingDesc=Namestitveni program je pripravljen za namestitev programa [name] v vaš raèunalnik.
+PreviousInstallNotCompleted=Namestitev ali odstranitev prejšnjega programa ni bila konèana. Da bi jo dokonèali, morate raèunalnik znova zagnati.%n%nPo ponovnem zagonu raèunalnika znova zaženite namestitveni program, da boste konèali namestitev programa [name].
+CannotContinue=Namestitveni program ne more nadaljevati. Pritisnite Preklièi za izhod.
+
+; *** "Installing" wizard page
+ApplicationsFound=Naslednji programi uporabljajo datoteke, ki jih mora namestitveni program posodobiti. Priporoèljivo je, da namestitvenemu programu dovolite, da te programe konèa.
+ApplicationsFound2=Naslednji programi uporabljajo datoteke, ki jih mora namestitveni program posodobiti. Priporoèljivo je, da namestitvenemu programu dovolite, da te programe konèa. Po koncu namestitve bo namestitveni program poizkusil znova zagnati te programe.
+CloseApplications=S&amodejno zapri programe
+DontCloseApplications=&Ne zapri programov
+ErrorCloseApplications=Namestitvenemu programu ni uspelo samodejno zapreti vseh programov. Priporoèljivo je, da pred nadaljevanjem zaprete vse programe, ki uporabljajo datoteke, katere mora namestitev posodobiti.
+PrepareToInstallNeedsRestart=Namestitveni program mora znova zagnati vaš raèunalnik. Za dokonèanje namestitve programa [name], po ponovnem zagonu znova zaženite namestitveni program.%n%nAli želite zdaj znova zagnati raèunalnik?
+
+WizardInstalling=Namešèanje
+InstallingLabel=Poèakajte, da bo program [name] namešèen v vaš raèunalnik.
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=Zakljuèek namestitve programa [name]
+FinishedLabelNoIcons=Program [name] je namešèen v vaš raèunalnik.
+FinishedLabel=Program [name] je namešèen v vaš raèunalnik. Program zaženete tako, da odprete pravkar ustvarjene programske ikone.
+ClickFinish=Kliknite tipko Konèaj za zakljuèek namestitve.
+FinishedRestartLabel=Za dokonèanje namestitve programa [name] morate raèunalnik znova zagnati. Ali ga želite znova zagnati zdaj?
+FinishedRestartMessage=Za dokonèanje namestitve programa [name] morate raèunalnik znova zagnati. %n%nAli ga želite znova zagnati zdaj?
+ShowReadmeCheck=Želim prebrati datoteko BERIME
+YesRadio=&Da, raèunalnik znova zaženi zdaj
+NoRadio=&Ne, raèunalnik bom znova zagnal pozneje
+
+; used for example as 'Run MyProg.exe'
+RunEntryExec=Zaženi %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=Preglej %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=Namestitveni program potrebuje naslednji disk
+SelectDiskLabel2=Vstavite disk %1 in kliknite V redu.%n%nÈe se datoteke s tega diska nahajajo v drugi mapi kot je navedena spodaj, vnesite pravilno pot ali kliknite Prebrskaj.
+PathLabel=&Pot:
+FileNotInDir2=Datoteke »%1« ni v mapi »%2«. Vstavite pravilni disk ali izberite drugo mapo.
+SelectDirectoryLabel=Vnesite mesto naslednjega diska.
+
+; *** Installation phase messages
+SetupAborted=Namestitev ni bila konèana.%n%nOdpravite težavo in znova odprite namestitveni program.
+AbortRetryIgnoreSelectAction=Izberite dejanje
+AbortRetryIgnoreRetry=Poizkusi &znova
+AbortRetryIgnoreIgnore=&Prezri napako in nadaljuj
+AbortRetryIgnoreCancel=Preklièi namestitev
+
+; *** Installation status messages
+StatusClosingApplications=Zapiranje programov...
+StatusCreateDirs=Ustvarjanje map...
+StatusExtractFiles=Razširjanje datotek...
+StatusCreateIcons=Ustvarjanje bližnjic...
+StatusCreateIniEntries=Vpisovanje v INI datoteke...
+StatusCreateRegistryEntries=Ustvarjanje vnosov v register...
+StatusRegisterFiles=Registriranje datotek...
+StatusSavingUninstall=Zapisovanje podatkov za odstranitev...
+StatusRunProgram=Zakljuèevanje namestitve...
+StatusRestartingApplications=Zaganjanje programov...
+StatusRollback=Obnavljanje prvotnega stanja...
+
+; *** Misc. errors
+ErrorInternal2=Interna napaka: %1
+ErrorFunctionFailedNoCode=%1 ni uspel(a)
+ErrorFunctionFailed=%1 ni uspel(a); koda %2
+ErrorFunctionFailedWithMessage=%1 ni uspela; koda %2.%n%3
+ErrorExecutingProgram=Ne morem zagnati programa:%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=Napaka pri odpiranju kljuèa v registru:%n%1\%2
+ErrorRegCreateKey=Napaka pri ustvarjanju kljuèa v registru:%n%1\%2
+ErrorRegWriteKey=Napaka pri pisanju kljuèa v registru:%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=Napaka pri vpisu v INI datoteko »%1«.
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=Pre&skoèi to datoteko (ni priporoèeno)
+FileAbortRetryIgnoreIgnoreNotRecommended=Prezr&i napako in nadaljuj (ni priporoèeno)
+SourceIsCorrupted=Izvorna datoteka je okvarjena
+SourceDoesntExist=Izvorna datoteka »%1« ne obstaja
+ExistingFileReadOnly2=Obstojeèe datoteke ni mogoèe nadomestiti, ker ima oznako samo za branje.
+ExistingFileReadOnlyRetry=Odst&rani oznako samo za branje in poizkusi ponovno
+ExistingFileReadOnlyKeepExisting=&Ohrani obstojeèo datoteko
+ErrorReadingExistingDest=Pri branju obstojeèe datoteke je prišlo do napake:
+FileExistsSelectAction=Izberite dejanje
+FileExists2=Datoteka že obstaja.
+FileExistsOverwriteExisting=&Prepiši obstojeèo datoteko
+FileExistsKeepExisting=&Ohrani trenutno datoteko
+FileExistsOverwriteOrKeepAll=&To naredite za preostale spore
+ExistingFileNewerSelectAction=Izberite dejanje
+ExistingFileNewer2=Obstojeèa datoteka je novejša, kot datoteka, ki se namešèa.
+ExistingFileNewerOverwriteExisting=&Prepiši obstojeèo datoteko
+ExistingFileNewerKeepExisting=&Ohrani trenutno datoteko (priporoèeno)
+ExistingFileNewerOverwriteOrKeepAll=&To naredite za preostale spore
+ErrorChangingAttr=Pri poskusu spremembe lastnosti datoteke je prišlo do napake:
+ErrorCreatingTemp=Pri ustvarjanju datoteke v ciljni mapi je prišlo do napake:
+ErrorReadingSource=Pri branju izvorne datoteke je prišlo do napake:
+ErrorCopying=Pri kopiranju datoteke je prišlo do napake:
+ErrorReplacingExistingFile=Pri poskusu zamenjave obstojeèe datoteke je prišlo do napake:
+ErrorRestartReplace=Napaka RestartReplace:
+ErrorRenamingTemp=Pri poskusu preimenovanja datoteke v ciljni mapi je prišlo do napake:
+ErrorRegisterServer=Registracija DLL/OCX ni uspela: %1
+ErrorRegSvr32Failed=RegSvr32 ni uspel s kodo napake %1
+ErrorRegisterTypeLib=Registracija TypeLib ni uspela: %1
+
+; *** Uninstall display name markings
+UninstallDisplayNameMark=%1 (%2)
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32-bitno
+UninstallDisplayNameMark64Bit=64-bitno
+UninstallDisplayNameMarkAllUsers=vsi uporabniki
+UninstallDisplayNameMarkCurrentUser=trenutni uporabnik
+
+; *** Post-installation errors
+ErrorOpeningReadme=Pri odpiranju datoteke BERIME je prišlo do napake.
+ErrorRestartingComputer=Namestitvenemu programu ni uspelo znova zagnati raèunalnika. Sami znova zaženite raèunalnik.
+
+; *** Uninstaller messages
+UninstallNotFound=Datoteka »%1« ne obstaja. Odstranitev ni mogoèa.
+UninstallOpenError=Datoteke »%1« ne morem odpreti. Ne morem odstraniti
+UninstallUnsupportedVer=Dnevniška datoteka »%1« je v obliki, ki je ta razlièica odstranitvenega programa ne razume. Programa ni mogoèe odstraniti
+UninstallUnknownEntry=V dnevniški datoteki je bil najden neznani vpis (%1)
+ConfirmUninstall=Ste preprièani, da želite v celoti odstraniti program %1 in pripadajoèe komponente?
+UninstallOnlyOnWin64=To namestitev je mogoèe odstraniti le v 64-bitni razlièici sistema Windows.
+OnlyAdminCanUninstall=Za odstranitev tega programa morate imeti skrbniške pravice.
+UninstallStatusLabel=Poèakajte, da se program %1 odstrani iz vašega raèunalnika.
+UninstalledAll=Program %1 je bil uspešno odstranjen iz vašega raèunalnika.
+UninstalledMost=Odstranjevanje programa %1 je konèano.%n%nNekatere datoteke niso bile odstranjene in jih lahko odstranite roèno.
+UninstalledAndNeedsRestart=Za dokonèanje odstranitve programa %1 morate raèunalnik znova zagnati.%n%nAli ga želite znova zagnati zdaj?
+UninstallDataCorrupted=Datoteka »%1« je okvarjena. Odstranitev ni možna
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=Želite odstraniti datoteko v skupni rabi?
+ConfirmDeleteSharedFile2=Spodaj izpisane datoteke v skupni rabi ne uporablja veè noben program. Želite odstraniti to datoteko?%n%nÈe jo uporablja katerikoli program in jo boste odstranili, ta program verjetno ne bo veè deloval pravilno. Èe niste preprièani, kliknite Ne. Èe boste datoteko ohranili v raèunalniku, ne bo niè narobe.
+SharedFileNameLabel=Ime datoteke:
+SharedFileLocationLabel=Mesto:
+WizardUninstalling=Odstranjevanje programa
+StatusUninstalling=Odstranjujem %1...
+
+ShutdownBlockReasonInstallingApp=Namešèam %1.
+ShutdownBlockReasonUninstallingApp=Odstranjujem %1.
+
+[CustomMessages]
+
+NameAndVersion=%1 razlièica %2
+AdditionalIcons=Dodatne ikone:
+CreateDesktopIcon=Ustvari ikono na &namizju
+CreateQuickLaunchIcon=Ustvari ikono za &hitri zagon
+ProgramOnTheWeb=%1 na spletu
+UninstallProgram=Odstrani %1
+LaunchProgram=Odpri %1
+AssocFileExtension=&Poveži %1 s pripono %2
+AssocingFileExtension=Povezujem %1 s pripono %2...
+AutoStartProgramGroupDescription=Zagon:
+AutoStartProgram=Samodejno zaženi %1
+AddonHostProgramNotFound=Programa %1 ni bilo mogoèe najti v izbrani mapi.%n%nAli želite vseeno nadaljevati?


### PR DESCRIPTION
- Add Simplify Chinese support to install package
- Adding/updating languages only requires modifying the language file inside project folder

> No longer requires copying the language to the compiler langurage environment
> Of course, If customised installation interface is not required, there's no need to change the language translation of the installation package in theory