### PR TITLE
Installer: Fix garbled message in Chinese (Maybe)

### DIFF
--- a/deploy/FortFirewall.iss
+++ b/deploy/FortFirewall.iss
@@ -57,8 +57,8 @@ Name: "zh_CN"; MessagesFile: "{#LANG_PATH}\ChineseSimplified.isl"
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"
 Name: "explorer"; Description: "{cm:WindowsExplorerIntegration}"
-Name: "service"; Description: "Windows Service"
-Name: "portable"; Description: "Portable"; Flags: unchecked
+Name: "service"; Description: "{cm:WindowsService}"
+Name: "portable"; Description: "{cm:Portable}"; Flags: unchecked
 
 [Files]
 Source: "build\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs

--- a/deploy/languages/ChineseSimplified.isl
+++ b/deploy/languages/ChineseSimplified.isl
@@ -1,4 +1,4 @@
-; *** Inno Setup version 6.1.0+ Chinese Simplified messages ***
+﻿; *** Inno Setup version 6.1.0+ Chinese Simplified messages ***
 ;
 ; To download user-contributed translations of this file, go to:
 ;   https://jrsoftware.org/files/istrans/

--- a/deploy/languages/ChineseSimplified.isl
+++ b/deploy/languages/ChineseSimplified.isl
@@ -401,4 +401,6 @@ AutoStartProgram=自动启动 %1
 AddonHostProgramNotFound=%1无法找到您所选择的文件夹。%n%n您想要继续吗？
 
 ; *** Fort Firewall messages
-WindowsExplorerIntegration=Windows Explorer integration
+WindowsExplorerIntegration=集成到 Windows 资源管理器
+WindowsService=添加Windows服务
+Portable=便携

--- a/deploy/languages/Default.isl
+++ b/deploy/languages/Default.isl
@@ -7,3 +7,5 @@ LanguageCodePage=0
 
 ; *** Fort Firewall messages
 WindowsExplorerIntegration=Windows Explorer integration
+WindowsService=Windows Service
+Portable=Portable


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49258735/236701428-99cb5580-78d2-442b-bb3e-cae8dba9bc51.png)

Compile test passed in pure Windows sandbox, hope it works on your computer as well
( I have no idea, cause in computer with simplified Chinese it was always worked)

> PS: garbled message shown below:
> ![image](https://user-images.githubusercontent.com/49258735/236700700-ac4be54b-dbba-478b-8bb4-9929ab47b372.png)
